### PR TITLE
feat(BOUN-1234): add system and sharded load shedders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ instant-acme = { version = "0.7.1", default-features = false, features = [
     "ring",
     "hyper-rustls",
 ] }
-little-loadshedder = "0.2.0"
 mockall = "0.12"
 moka = { version = "0.12", features = ["sync", "future"] }
 prometheus = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ instant-acme = { version = "0.7.1", default-features = false, features = [
     "ring",
     "hyper-rustls",
 ] }
+little-loadshedder = "0.2.0"
 mockall = "0.12"
 moka = { version = "0.12", features = ["sync", "future"] }
 prometheus = "0.13"
@@ -67,6 +68,7 @@ sha1 = "0.10"
 strum = { version = "0.26", features = ["derive"] }
 strum_macros = "0.26"
 sync_wrapper = "1.0"
+systemstat = "0.2.3"
 thiserror = "1.0"
 tokio = { version = "1.40", features = ["full"] }
 tokio-util = { version = "0.7", features = ["full"] }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -5,6 +5,7 @@ pub mod dns;
 pub mod headers;
 pub mod proxy;
 pub mod server;
+pub mod shed;
 
 use std::{
     io,

--- a/src/http/shed/ewma.rs
+++ b/src/http/shed/ewma.rs
@@ -1,0 +1,132 @@
+/// Implementation of Exponential Weighted Moving Average.
+/// https://en.wikipedia.org/wiki/Exponential_smoothing#Basic_(simple)_exponential_smoothing
+pub struct EWMA {
+    alpha: f64,
+    new: bool,
+    value: f64,
+}
+
+impl EWMA {
+    pub fn new(alpha: f64) -> Self {
+        assert!((0.0..=1.0).contains(&alpha));
+
+        Self {
+            new: true,
+            value: 0.0,
+            alpha,
+        }
+    }
+
+    pub fn add(&mut self, v: f64) {
+        if self.new {
+            self.new = false;
+            self.value = v;
+            return;
+        }
+
+        // Use FMA instruction for faster and more precise calculation of a*b + c
+        self.value = self.alpha.mul_add(v - self.value, self.value)
+    }
+
+    pub const fn get(&self) -> Option<f64> {
+        if self.new {
+            return None;
+        }
+
+        Some(self.value)
+    }
+}
+
+/// Implementation of Double Exponential Weighted Moving Average.
+/// https://en.wikipedia.org/wiki/Exponential_smoothing#Double_exponential_smoothing_(Holt_linear)
+pub struct DEWMA {
+    alpha: f64,
+    beta: f64,
+
+    iter: u8,
+    value: f64,
+    trend: f64,
+}
+
+impl DEWMA {
+    pub fn new(alpha: f64, beta: f64) -> Self {
+        assert!((0.0..=1.0).contains(&alpha));
+        assert!((0.0..=1.0).contains(&beta));
+
+        Self {
+            iter: 0,
+            value: 0.0,
+            trend: 0.0,
+            alpha,
+            beta,
+        }
+    }
+
+    pub fn add(&mut self, v: f64) {
+        if self.iter == 0 {
+            self.iter += 1;
+            self.value = v;
+            return;
+        } else if self.iter == 1 {
+            // Initialize the trend on 2nd measurement
+            self.iter += 1;
+            self.trend = v - self.value;
+        }
+
+        let value_old = self.value;
+
+        // Use FMA instruction for faster and more precise calculation of a*b + c
+        self.value = self
+            .alpha
+            .mul_add(v, (1.0 - self.alpha) * (self.value + self.trend));
+        self.trend = self
+            .beta
+            .mul_add(self.value - value_old, (1.0 - self.beta) * self.trend);
+    }
+
+    pub fn get(&self, m: f64) -> Option<f64> {
+        // The function is undefined for the 1st measurement
+        if self.iter < 2 {
+            return None;
+        }
+
+        Some(m.mul_add(self.trend, self.value))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_ewma() {
+        let mut e = EWMA::new(0.7);
+
+        assert!(e.get().is_none());
+        e.add(100.0);
+        assert_eq!(e.get().unwrap(), 100.0);
+        e.add(150.0);
+        assert_eq!(e.get().unwrap(), 135.0);
+        e.add(150.0);
+        assert_eq!(e.get().unwrap(), 145.5);
+        e.add(150.0);
+        assert_eq!(e.get().unwrap(), 148.65);
+    }
+
+    #[test]
+    fn test_dewma() {
+        let mut e = DEWMA::new(0.7, 0.6);
+
+        e.add(100.0);
+        assert!(e.get(0.0).is_none());
+        e.add(150.0);
+        assert_eq!(e.get(0.0).unwrap(), 150.0);
+        e.add(200.0);
+        assert_eq!(e.get(0.0).unwrap(), 200.0);
+        e.add(300.0);
+        assert_eq!(e.get(0.0).unwrap(), 285.0);
+        assert_eq!(e.get(1.0).unwrap(), 356.0);
+        e.add(300.0);
+        assert_eq!(e.get(0.0).unwrap(), 316.8);
+    }
+}

--- a/src/http/shed/little.rs
+++ b/src/http/shed/little.rs
@@ -1,0 +1,389 @@
+//! A load-shedding middleware based on [Little's law].
+//!
+//! This provides middleware for shedding load to maintain a target average
+//! latency, see the documentation on the [`LoadShed`] service for more detail.
+//!
+//! [Little's law]: https://en.wikipedia.org/wiki/Little%27s_law
+//! [metrics]: https://docs.rs/metrics/latest/metrics
+//!
+//! (c) https://github.com/Skepfyr/little-loadshedder
+
+#![warn(missing_debug_implementations, missing_docs)]
+#![allow(clippy::significant_drop_tightening)]
+#![allow(clippy::significant_drop_in_scrutinee)]
+#![forbid(unsafe_code)]
+
+use std::{
+    cmp::Ordering,
+    future::Future,
+    pin::Pin,
+    sync::{atomic::AtomicU64, Arc, Mutex},
+    task::{Context, Poll},
+    time::{Duration, Instant},
+};
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, TryAcquireError};
+use tower::{Layer, Service, ServiceExt};
+
+/// Load Shed service's current state of the world
+#[derive(Debug, Clone)]
+struct LoadShedConf {
+    /// The number of initial requests to pass without shedding
+    passthrough_count: u64,
+    /// The target average latency in seconds.
+    target: f64,
+    /// The exponentially weighted moving average parameter.
+    /// Must be in the range (0, 1), `0.25` means new value accounts for 25% of
+    /// the moving average.
+    ewma_param: f64,
+    /// Semaphore controlling the waiting queue of requests.
+    available_queue: Arc<Semaphore>,
+    /// Semaphore controlling concurrency to the inner service.
+    available_concurrency: Arc<Semaphore>,
+    /// Stats about the latency that change with each completed request.
+    stats: Arc<Mutex<ConfStats>>,
+    /// Number of requests that were served
+    requests: Arc<AtomicU64>,
+}
+
+#[derive(Debug)]
+struct ConfStats {
+    /// The current average latency in seconds.
+    average_latency: f64,
+    /// The average of the latency measured when
+    /// `available_concurrent.available_permits() == 0`.
+    average_latency_at_capacity: f64,
+    /// The number of available permits in the queue semaphore
+    /// (the current capacity of the queue).
+    queue_capacity: usize,
+    /// The number of permits in the available_concurrency semaphore.
+    concurrency: usize,
+    /// The value of `self.concurrency` before it was last changed.
+    previous_concurrency: usize,
+    /// The time that the concurrency was last adjusted, to rate limit changing it.
+    last_changed: Instant,
+    /// Average throughput when at the previous concurrency value.
+    previous_throughput: f64,
+}
+
+// size of system [req] = target latency [s] * throughput [r/s]
+// size of queue [req] = size of system [req] - concurrency [req]
+// throughput [req/s] = concurrency [req] / average latency of service [s]
+// => (size of queue [req] + concurrency[req]) = target latency [s] * concurrency[req] / latency [s]
+// => size of queue [req] = concurrency [req] * (target latency [s] / latency [s] - 1)
+//
+// Control the concurrency:
+// increase concurrency but not beyond target latency
+//
+// Control queue length:
+// queue capacity = concurrency * ((target latency / average latency of service) - 1)
+
+impl LoadShedConf {
+    fn new(ewma_param: f64, target: f64, passthrough_count: u64) -> Self {
+        Self {
+            passthrough_count,
+            target,
+            ewma_param,
+            available_concurrency: Arc::new(Semaphore::new(1)),
+            available_queue: Arc::new(Semaphore::new(1)),
+            stats: Arc::new(Mutex::new(ConfStats {
+                average_latency: target,
+                average_latency_at_capacity: target,
+                queue_capacity: 1,
+                concurrency: 1,
+                previous_concurrency: 0,
+                last_changed: Instant::now(),
+                previous_throughput: 0.0,
+            })),
+            requests: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Add ourselves to the queue and wait until we've made it through and have
+    /// obtained a permit to send the request.
+    async fn start(&self) -> Option<OwnedSemaphorePermit> {
+        {
+            // Work inside a block so we drop the stats lock asap.
+            let mut stats = self.stats.lock().unwrap();
+            let desired_queue_capacity = usize::max(
+                1, // The queue must always be at least 1 request long.
+                // Use average latency at (concurrency) capacity so that this doesn't
+                // grow too large while the system is under-utilised.
+                (stats.concurrency as f64
+                    * ((self.target / stats.average_latency_at_capacity) - 1.0))
+                    .floor() as usize,
+            );
+
+            // Adjust the semaphore capacity by adding or acquiring many permits.
+            // If acquiring permits fails we can return overload and let the next
+            // request recompute the queue capacity.
+            match desired_queue_capacity.cmp(&stats.queue_capacity) {
+                Ordering::Less => {
+                    match self
+                        .available_queue
+                        .try_acquire_many((stats.queue_capacity - desired_queue_capacity) as u32)
+                    {
+                        Ok(permits) => permits.forget(),
+                        Err(TryAcquireError::NoPermits) => return None,
+                        Err(TryAcquireError::Closed) => panic!(),
+                    }
+                }
+                Ordering::Equal => {}
+                Ordering::Greater => self
+                    .available_queue
+                    .add_permits(desired_queue_capacity - stats.queue_capacity),
+            }
+            stats.queue_capacity = desired_queue_capacity;
+        }
+
+        // Finally get our queue permit, if this fails then the queue is full
+        // and we need to bail out.
+        let queue_permit = match self.available_queue.clone().try_acquire_owned() {
+            Ok(queue_permit) => queue_permit,
+            Err(TryAcquireError::NoPermits) => return None,
+            Err(TryAcquireError::Closed) => panic!("queue semaphore closed?"),
+        };
+
+        // We're in the queue now so wait until we get ourselves a concurrency permit.
+        let concurrency_permit = self
+            .available_concurrency
+            .clone()
+            .acquire_owned()
+            .await
+            .unwrap();
+
+        // Now we've got the permit required to send the request we can leave the queue.
+        drop(queue_permit);
+        Some(concurrency_permit)
+    }
+
+    /// Register a completed call of the inner service, providing the latency to
+    /// update the statistics.
+    fn stop(&self, elapsed: Duration) {
+        let elapsed = elapsed.as_secs_f64();
+
+        // This function solely updates the stats (and is not async) so hold the
+        // lock for the entire function.
+        let mut stats = self.stats.lock().expect("To be able to lock stats");
+
+        let available_permits = self.available_concurrency.available_permits();
+        // Have some leeway on what "at max concurrency" means as you might
+        // otherwise never see this condition at large concurrency values.
+        let at_max_concurrency = available_permits <= usize::max(1, stats.concurrency / 10);
+
+        // Update the average latency using the EWMA algorithm.
+        stats.average_latency = stats
+            .average_latency
+            .mul_add(1.0 - self.ewma_param, self.ewma_param * elapsed);
+
+        if at_max_concurrency {
+            stats.average_latency_at_capacity = stats
+                .average_latency_at_capacity
+                .mul_add(1.0 - self.ewma_param, self.ewma_param * elapsed);
+        }
+
+        // Only ever change max concurrency if we're at the limit as we need
+        // measurements to have happened at the current limit.
+        // Also, introduce a max rate of change that's somewhat magically
+        // related to the latency and ewma parameter to prevent this from
+        // changing too quickly.
+        if stats.last_changed.elapsed().as_secs_f64()
+            > (stats.average_latency / self.ewma_param) / 10.0
+            && at_max_concurrency
+        {
+            // Plausibly should be using average latency at capacity here and
+            // stats.concurrency but this appears to work. It might do weird
+            // things if it's been running under capacity for a while then spikes.
+            let current_concurrency = stats.concurrency - available_permits;
+            let throughput = current_concurrency as f64 / stats.average_latency;
+            // Was the throughput better or worse than it was previously.
+            let negative_gradient = (throughput > stats.previous_throughput)
+                ^ (current_concurrency > stats.previous_concurrency);
+            if negative_gradient || (stats.average_latency > self.target) {
+                // Don't reduce concurrency below 1 or everything stops.
+                if stats.concurrency > 1 {
+                    // negative gradient so decrease concurrency
+                    self.available_concurrency.forget_permits(1);
+                    stats.concurrency -= 1;
+
+                    // Adjust the average latency assuming that the change in
+                    // concurrency doesn't affect the service latency, which is
+                    // closer to the truth than the latency not changing.
+                    let latency_factor =
+                        stats.concurrency as f64 / (stats.concurrency as f64 + 1.0);
+                    stats.average_latency *= latency_factor;
+                    stats.average_latency_at_capacity *= latency_factor;
+                }
+            } else {
+                self.available_concurrency.add_permits(1);
+                stats.concurrency += 1;
+
+                // Adjust the average latency assuming that the change in
+                // concurrency doesn't affect the service latency, which is
+                // closer to the truth than the latency not changing.
+                let latency_factor = stats.concurrency as f64 / (stats.concurrency as f64 - 1.0);
+                stats.average_latency *= latency_factor;
+                stats.average_latency_at_capacity *= latency_factor;
+            }
+
+            stats.previous_throughput = throughput;
+            stats.previous_concurrency = current_concurrency;
+            stats.last_changed = Instant::now()
+        }
+    }
+}
+
+/// A [`Service`] that attempts to hold the average latency at a given target.
+///
+/// It does this by placing a queue in front of the service and rejecting
+/// requests when that queue is full (this means requests are either immediately
+/// rejected or will be processed by the inner service). It calculates the size
+/// of that queue using [Little's Law] which states that the average number of
+/// items in a system is equal to the average throughput multiplied by the
+/// average latency.
+///
+/// This service therefore measures the average latency and sets the queue size
+/// such that when the queue is full a request will on average take the target
+/// latency time to be responded to. Note that if the queue is not full the
+/// latency will be below the target.
+///
+/// This service also optimises the number concurrent requests to the service.
+/// This will usually be the same as the queue size, unless the target latency
+/// (and hence the queue) is very large, or the underlying service can cope with
+/// very few concurrent requests.
+///
+/// This service is reactive, if the underlying service degrades then the queues
+/// will shorten, if it improves they will lengthen. The queue lengths will be
+/// underestimates at startup and will only increase while the service is near
+/// its concurrency limit. Be wary of using the queue length as a measure of
+/// system capacity unless the queues have been at or above the concurrency for
+/// a while.
+///
+/// [Little's law]: https://en.wikipedia.org/wiki/Little%27s_law
+#[derive(Debug, Clone)]
+pub struct LoadShed<Inner> {
+    conf: LoadShedConf,
+    inner: Inner,
+}
+
+impl<Inner> LoadShed<Inner> {
+    /// Wrap a service with this middleware, using the given target average
+    /// latency and computing the current average latency using an exponentially
+    /// weighted moving average with the given parameter.
+    pub fn new(inner: Inner, ewma_param: f64, target: Duration, passthrough_count: u64) -> Self {
+        Self {
+            inner,
+            conf: LoadShedConf::new(ewma_param, target.as_secs_f64(), passthrough_count),
+        }
+    }
+
+    /// The current average latency of requests through the inner service,
+    /// that is ignoring the queue this service adds.
+    pub fn average_latency(&self) -> Duration {
+        Duration::from_secs_f64(self.conf.stats.lock().unwrap().average_latency)
+    }
+
+    /// The current maximum concurrency of requests to the inner service.
+    pub fn concurrency(&self) -> usize {
+        self.conf.stats.lock().unwrap().concurrency
+    }
+
+    /// The current maximum capacity of this service (including the queue).
+    pub fn queue_capacity(&self) -> usize {
+        let stats = self.conf.stats.lock().unwrap();
+        stats.concurrency + stats.queue_capacity
+    }
+
+    /// The current number of requests that have been accepted by this service.
+    pub fn queue_len(&self) -> usize {
+        let stats = self.conf.stats.lock().unwrap();
+        let current_concurrency =
+            stats.concurrency - self.conf.available_concurrency.available_permits();
+        let current_queue = stats.queue_capacity - self.conf.available_queue.available_permits();
+
+        current_concurrency + current_queue
+    }
+}
+
+/// Either an error from the wrapped service or message that the request was shed
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum LoadShedResponse<T> {
+    /// A response from the inner service.
+    Inner(T),
+    /// The request was shed due to overload.
+    Overload,
+}
+
+type BoxFuture<Output> = Pin<Box<dyn Future<Output = Output> + Send>>;
+
+impl<Request, Inner> Service<Request> for LoadShed<Inner>
+where
+    Request: Send + 'static,
+    Inner: Service<Request> + Clone + Send + 'static,
+    Inner::Future: Send,
+{
+    type Response = LoadShedResponse<Inner::Response>;
+    type Error = Inner::Error;
+    type Future = BoxFuture<Result<Self::Response, Self::Error>>;
+
+    /// Always ready because there's a queue between this service and the inner one.
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        // We're fine to use the clone because inner hasn't been polled to
+        // readiness yet.
+        let inner = self.inner.clone();
+        let conf = self.conf.clone();
+        let requests = conf
+            .requests
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+        Box::pin(async move {
+            let permit = conf.start().await;
+            // If there's no permit & we're past initial passthrough count - then do load shedding.
+            if permit.is_none() && requests >= conf.passthrough_count {
+                return Ok(LoadShedResponse::Overload);
+            }
+
+            let start = Instant::now();
+            // The elapsed time includes waiting for readiness which should help
+            // us stay under any upstream concurrency limiters.
+            let response = inner.oneshot(req).await;
+            conf.stop(start.elapsed());
+            Ok(LoadShedResponse::Inner(response?))
+        })
+    }
+}
+
+/// A [`Layer`] to wrap services in a [`LoadShed`] middleware.
+///
+/// See [`LoadShed`] for details of the load shedding algorithm.
+#[derive(Debug, Clone)]
+pub struct LoadShedLayer {
+    ewma_param: f64,
+    passthrough_count: u64,
+    target: Duration,
+}
+
+impl LoadShedLayer {
+    /// Create a new layer with the given target average latency and
+    /// computing the current average latency using an exponentially weighted
+    /// moving average with the given parameter.
+    pub const fn new(ewma_param: f64, target: Duration, passthrough_count: u64) -> Self {
+        Self {
+            ewma_param,
+            target,
+            passthrough_count,
+        }
+    }
+}
+
+impl<Inner> Layer<Inner> for LoadShedLayer {
+    type Service = LoadShed<Inner>;
+
+    fn layer(&self, inner: Inner) -> Self::Service {
+        LoadShed::new(inner, self.ewma_param, self.target, self.passthrough_count)
+    }
+}

--- a/src/http/shed/mod.rs
+++ b/src/http/shed/mod.rs
@@ -1,0 +1,294 @@
+pub mod ewma;
+
+use std::{
+    collections::BTreeMap,
+    fmt::Debug,
+    future::Future,
+    pin::Pin,
+    sync::{Arc, RwLock},
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use anyhow::{anyhow, Context as _};
+use async_trait::async_trait;
+use ewma::EWMA;
+use http::Request;
+use little_loadshedder::LoadShed;
+use systemstat::{Platform, System};
+use tokio_util::sync::CancellationToken;
+use tower::{Layer, Service, ServiceExt};
+use tracing::{error, warn};
+
+use crate::{tasks::Run, Error};
+
+#[async_trait]
+pub trait GetsSystemInfo: Send + Sync + Clone {
+    async fn cpu_usage(&self) -> Result<f64, Error>;
+    fn memory_usage(&self) -> Result<f64, Error>;
+    fn load_avg(&self) -> Result<(f64, f64, f64), Error>;
+}
+
+/// Trait to extract the shedding key and latency threshold from the given HTTP request
+pub trait TypeExtractor: Clone + Debug + Send + Sync + 'static {
+    /// The type of the key.
+    type Type: Clone + Debug + Send + Sync + Ord + 'static;
+
+    /// Extraction method, will return [`Error`] response when the extraction failed
+    fn extract<T>(&self, req: &Request<T>) -> Result<Self::Type, Error>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ShedReason {
+    CPU,
+    Memory,
+    LoadAvg,
+    Latency,
+}
+
+/// Either an error from the wrapped service or message that the request was shed
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ShedResponse<T> {
+    /// A response from the inner service.
+    Inner(T),
+    /// The request was shed due to overload.
+    Overload(ShedReason),
+}
+
+#[derive(Clone)]
+pub struct SystemInfo(Arc<System>);
+
+impl SystemInfo {
+    pub fn new() -> Self {
+        Self(Arc::new(System::new()))
+    }
+}
+
+impl Default for SystemInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl GetsSystemInfo for SystemInfo {
+    async fn cpu_usage(&self) -> Result<f64, Error> {
+        let cpu = self
+            .0
+            .cpu_load_aggregate()
+            .context("unable to measure CPU load")?;
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        let cpu = cpu.done().context("unable to measure CPU load")?;
+
+        Ok(1.0 - cpu.idle as f64)
+    }
+
+    fn memory_usage(&self) -> Result<f64, Error> {
+        let mem = self.0.memory().context("unable to measure memory usage")?;
+        if mem.total.as_u64() == 0 {
+            return Err(anyhow!("total memory is zero").into());
+        }
+
+        Ok(1.0 - mem.free.as_u64() as f64 / mem.total.as_u64() as f64)
+    }
+
+    fn load_avg(&self) -> Result<(f64, f64, f64), Error> {
+        let la = self
+            .0
+            .load_average()
+            .context("unable to measure load average")?;
+
+        Ok((la.one as f64, la.five as f64, la.fifteen as f64))
+    }
+}
+
+struct Averages {
+    cpu: EWMA,
+    memory: EWMA,
+    load_avg: (EWMA, EWMA, EWMA),
+}
+
+impl Averages {
+    fn new(alpha: f64) -> Self {
+        Self {
+            cpu: EWMA::new(alpha),
+            memory: EWMA::new(alpha),
+            load_avg: (EWMA::new(alpha), EWMA::new(alpha), EWMA::new(alpha)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SystemOptions {
+    pub ewma_alpha: f64,
+    pub cpu: Option<f64>,
+    pub memory: Option<f64>,
+    pub loadavg_1: Option<f64>,
+    pub loadavg_5: Option<f64>,
+    pub loadavg_15: Option<f64>,
+}
+
+/// Load shedder that sheds requests when the system load is ovet the defined thresholds
+pub struct SystemLoadShedder<S: GetsSystemInfo, I> {
+    sys_info: S,
+    avg: RwLock<Averages>,
+    opts: SystemOptions,
+    inner: I,
+}
+
+impl<S: GetsSystemInfo, I: Send + Sync> SystemLoadShedder<S, I> {
+    pub fn new(inner: I, opts: SystemOptions, sys_info: S) -> Self {
+        Self {
+            sys_info,
+            avg: RwLock::new(Averages::new(opts.ewma_alpha)),
+            opts,
+            inner,
+        }
+    }
+
+    async fn measure(&self) -> Result<(), Error> {
+        let cpu = self.sys_info.cpu_usage().await?;
+        let mem = self.sys_info.memory_usage()?;
+        let (l1, l5, l15) = self.sys_info.load_avg()?;
+
+        let mut avg = self.avg.write().unwrap();
+        avg.cpu.add(cpu);
+        avg.memory.add(mem);
+        avg.load_avg.0.add(l1);
+        avg.load_avg.1.add(l5);
+        avg.load_avg.2.add(l15);
+        drop(avg); // clippy
+
+        Ok(())
+    }
+
+    fn evaluate(&self) -> Option<ShedReason> {
+        let avg = self.avg.read().unwrap();
+
+        if self
+            .opts
+            .cpu
+            .map(|x| avg.cpu.get().unwrap_or(0.0) > x)
+            .unwrap_or(false)
+        {
+            return Some(ShedReason::CPU);
+        }
+
+        if self
+            .opts
+            .memory
+            .map(|x| avg.memory.get().unwrap_or(0.0) > x)
+            .unwrap_or(false)
+        {
+            return Some(ShedReason::Memory);
+        }
+
+        if self
+            .opts
+            .loadavg_1
+            .map(|x| avg.load_avg.0.get().unwrap_or(0.0) > x)
+            .unwrap_or(false)
+        {
+            return Some(ShedReason::LoadAvg);
+        }
+
+        if self
+            .opts
+            .loadavg_5
+            .map(|x| avg.load_avg.1.get().unwrap_or(0.0) > x)
+            .unwrap_or(false)
+        {
+            return Some(ShedReason::LoadAvg);
+        }
+
+        if self
+            .opts
+            .loadavg_15
+            .map(|x| avg.load_avg.2.get().unwrap_or(0.0) > x)
+            .unwrap_or(false)
+        {
+            return Some(ShedReason::LoadAvg);
+        }
+
+        None
+    }
+}
+
+#[async_trait]
+impl<S: GetsSystemInfo, I: Send + Sync> Run for SystemLoadShedder<S, I> {
+    async fn run(&self, token: CancellationToken) -> Result<(), anyhow::Error> {
+        let mut interval = tokio::time::interval(Duration::from_secs(2));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                biased;
+
+                () = token.cancelled() => {
+                    warn!("SystemLoadShedder: exiting");
+                    return Ok(());
+                }
+
+                _ = interval.tick() => {
+                    if let Err(e) = self.measure().await {
+                        error!("SystemLoadShedder: error: {e:#}");
+                    }
+                },
+            }
+        }
+    }
+}
+
+type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+
+// Implement tower service
+impl<S: GetsSystemInfo, R, I> Service<R> for SystemLoadShedder<S, I>
+where
+    R: Send + 'static,
+    I: Service<R> + Clone + Send + Sync + 'static,
+    I::Future: Send,
+{
+    type Response = ShedResponse<I::Response>;
+    type Error = I::Error;
+    type Future = BoxFuture<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        // Check if we need to shed the load
+        if let Some(v) = self.evaluate() {
+            return Box::pin(async move { Ok(ShedResponse::Overload(v)) });
+        }
+
+        let inner = self.inner.clone();
+        Box::pin(async move {
+            let response = inner.oneshot(req).await;
+            Ok(ShedResponse::Inner(response?))
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SystemLoadShedderLayer<S: GetsSystemInfo>(SystemOptions, S);
+
+impl<S: GetsSystemInfo> SystemLoadShedderLayer<S> {
+    pub const fn new(opts: SystemOptions, sys_info: S) -> Self {
+        Self(opts, sys_info)
+    }
+}
+
+impl<S: GetsSystemInfo, I: Send + Sync> Layer<I> for SystemLoadShedderLayer<S> {
+    type Service = SystemLoadShedder<S, I>;
+
+    fn layer(&self, inner: I) -> Self::Service {
+        SystemLoadShedder::new(inner, self.0, self.1.clone())
+    }
+}
+
+pub struct ShardedLittleLoadShedder<T: TypeExtractor, I> {
+    extract: T,
+    inner: I,
+    shards: BTreeMap<T::Type, LoadShed<I>>,
+}

--- a/src/http/shed/mod.rs
+++ b/src/http/shed/mod.rs
@@ -1,4 +1,5 @@
 pub mod ewma;
+pub mod little;
 
 use std::{
     collections::BTreeMap,
@@ -13,7 +14,7 @@ use std::{
 use anyhow::{anyhow, Context as _};
 use async_trait::async_trait;
 use ewma::EWMA;
-use little_loadshedder::{LoadShed, LoadShedResponse};
+use little::{LoadShed, LoadShedResponse};
 use systemstat::{Platform, System};
 use tokio_util::sync::CancellationToken;
 use tower::{Layer, Service, ServiceExt};
@@ -35,7 +36,7 @@ pub trait TypeExtractor: Clone + Debug + Send + Sync + 'static {
     type Request: Send + Sync;
 
     /// Extraction method, will return [`Error`] response when the extraction failed
-    fn extract(&self, req: &Self::Request) -> Result<Self::Type, Error>;
+    fn extract(&self, req: &Self::Request) -> Option<Self::Type>;
 }
 
 /// Reason for shedding
@@ -290,9 +291,10 @@ impl<S: GetsSystemInfo, I: Send + Sync> Layer<I> for SystemLoadShedderLayer<S> {
 
 #[derive(Debug, Clone)]
 pub struct ShardedOptions<T: TypeExtractor> {
-    extractor: T,
-    ewma_alpha: f64,
-    latencies: Vec<(T::Type, Duration)>,
+    pub extractor: T,
+    pub ewma_alpha: f64,
+    pub passthrough_count: u64,
+    pub latencies: Vec<(T::Type, Duration)>,
 }
 
 #[derive(Debug, Clone)]
@@ -305,17 +307,24 @@ pub struct ShardedLittleLoadShedder<T: TypeExtractor, I> {
 impl<T: TypeExtractor, I: Send + Sync + Clone> ShardedLittleLoadShedder<T, I> {
     pub fn new(inner: I, opts: ShardedOptions<T>) -> Self {
         // Generate the shedding shards, one per provided request type
-        let shards = BTreeMap::from_iter(
-            opts.latencies
-                .into_iter()
-                .map(|x| (x.0, LoadShed::new(inner.clone(), opts.ewma_alpha, x.1))),
-        );
+        let shards = BTreeMap::from_iter(opts.latencies.into_iter().map(|x| {
+            (
+                x.0,
+                LoadShed::new(inner.clone(), opts.ewma_alpha, x.1, opts.passthrough_count),
+            )
+        }));
 
         Self {
             extractor: opts.extractor,
             inner,
             shards,
         }
+    }
+
+    // Tries to find a shard corresponding to the given request
+    fn get_shard(&self, req: &T::Request) -> Option<LoadShed<I>> {
+        let req_type = self.extractor.extract(req)?;
+        self.shards.get(&req_type).cloned()
     }
 }
 
@@ -334,16 +343,9 @@ where
     }
 
     fn call(&mut self, req: T::Request) -> Self::Future {
-        // Try to extract the request type
-        let Ok(rt) = self.extractor.extract(&req) else {
-            // If we can't - just pass the request to the inner service
-            let inner = self.inner.clone();
-            return Box::pin(async move { Ok(ShedResponse::Inner(inner.oneshot(req).await?)) });
-        };
-
-        // Try to find if we have a shard for it
-        let Some(shard) = self.shards.get(&rt).cloned() else {
-            // If we don't have it - again just pass the request to the inner service
+        // Try to find if we have a shard
+        let Some(shard) = self.get_shard(&req) else {
+            // If we don't - just pass the request to the inner service
             let inner = self.inner.clone();
             return Box::pin(async move { Ok(ShedResponse::Inner(inner.oneshot(req).await?)) });
         };
@@ -445,8 +447,8 @@ mod test {
         type Request = Duration;
         type Type = u8;
 
-        fn extract(&self, _req: &Self::Request) -> Result<Self::Type, Error> {
-            return Ok(self.0);
+        fn extract(&self, _req: &Self::Request) -> Option<Self::Type> {
+            return Some(self.0);
         }
     }
 
@@ -515,6 +517,7 @@ mod test {
     async fn test_sharded_shedder() {
         let opts = ShardedOptions {
             extractor: StubExtractor(0),
+            passthrough_count: 100,
             ewma_alpha: 0.9,
             latencies: vec![(0, Duration::from_millis(1))],
         };
@@ -524,11 +527,32 @@ mod test {
 
         // Make sure sequential requests are not shedded no matter the latency
         for _ in 0..10 {
-            let resp = shedder.call(Duration::from_millis(50)).await.unwrap();
+            let resp = shedder.call(Duration::from_millis(10)).await.unwrap();
             assert_eq!(resp, ShedResponse::Inner(()));
         }
 
-        // Now try a lot of concurrent requests with high latency
+        // Now try 90 of concurrent requests with high latency
+        // They shouldn't be shedded due to passthrough_requests
+        let shedded = Arc::new(AtomicUsize::new(0));
+        let tracker = TaskTracker::new();
+        for _ in 0..90 {
+            let shedder = shedder.clone();
+            let shedded = shedded.clone();
+
+            tracker.spawn(async move {
+                let resp = shedder.oneshot(Duration::from_millis(10)).await.unwrap();
+                if matches!(resp, ShedResponse::Overload(ShedReason::Latency)) {
+                    shedded.fetch_add(1, Ordering::SeqCst);
+                }
+            });
+        }
+
+        tracker.close();
+        tracker.wait().await;
+        assert_eq!(shedded.load(Ordering::SeqCst), 0);
+
+        // Now try 10 of concurrent requests with high latency
+        // 8 of them should be shedded
         let shedded = Arc::new(AtomicUsize::new(0));
         let tracker = TaskTracker::new();
         for _ in 0..10 {
@@ -579,6 +603,7 @@ mod test {
         let opts = ShardedOptions {
             extractor: StubExtractor(1),
             ewma_alpha: 0.9,
+            passthrough_count: 0,
             latencies: vec![(0, Duration::from_millis(1))],
         };
         let inner = StubService;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,10 @@
 pub mod http;
 pub mod tasks;
 pub mod tls;
+
+/// Generic error
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Generic(#[from] anyhow::Error),
+}


### PR DESCRIPTION
This adds two load shedders:
* `ShardedLittleLoadShedder` which is a per-request-type sharded version of LittleLoadShedder crate
* `SystemLoadShedder` that sheds the load based on system load (cpu, memory, load average for now)

LittleLoadShedder is also forked to support `passthrough_requests` option to be able to bypass shedding for some initial number of requests