### PR TITLE
fix proxying + size_hint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,6 @@ serde_json = "1.0.132"
 sha1 = "0.10.6"
 strum = { version = "0.26.3", features = ["derive"] }
 strum_macros = "0.26.4"
-sync_wrapper = "1.0.1"
 systemstat = "0.2.3"
 thiserror = "2.0.3"
 tokio = { version = "1.42.0", features = ["full"] }

--- a/src/http/body.rs
+++ b/src/http/body.rs
@@ -1,6 +1,7 @@
 use std::{
     pin::{pin, Pin},
     sync::atomic::{AtomicBool, Ordering},
+    sync::Mutex,
     task::{Context, Poll},
     time::Duration,
 };
@@ -51,6 +52,86 @@ where
 }
 
 pub type BodyResult = Result<u64, String>;
+
+/// Wrapper that makes the provided body Sync
+#[derive(Debug)]
+pub struct SyncBody {
+    inner: Mutex<Pin<Box<Body>>>,
+}
+
+impl SyncBody {
+    pub fn new(inner: Body) -> Self {
+        Self {
+            inner: Mutex::new(Box::pin(inner)),
+        }
+    }
+}
+
+impl http_body::Body for SyncBody {
+    type Data = Bytes;
+    type Error = axum::Error;
+
+    #[inline]
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        self.inner.lock().unwrap().as_mut().poll_frame(cx)
+    }
+
+    #[inline]
+    fn is_end_stream(&self) -> bool {
+        self.inner.lock().unwrap().as_ref().is_end_stream()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.lock().unwrap().as_ref().size_hint()
+    }
+}
+
+/// Wrapper that overrides the size hint of the inner body
+#[derive(Debug)]
+pub struct HintBody {
+    inner: http_body_util::combinators::UnsyncBoxBody<Bytes, axum::Error>,
+    hint: SizeHint,
+}
+
+impl HintBody {
+    pub fn new<B>(body: B, size: Option<u64>) -> Self
+    where
+        B: http_body::Body<Data = Bytes> + Send + 'static,
+        B::Error: Into<axum::BoxError>,
+    {
+        Self {
+            inner: body.map_err(axum::Error::new).boxed_unsync(),
+            hint: size.map(SizeHint::with_exact).unwrap_or_default(),
+        }
+    }
+}
+
+impl http_body::Body for HintBody {
+    type Data = Bytes;
+    type Error = axum::Error;
+
+    #[inline]
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        Pin::new(&mut self.inner).poll_frame(cx)
+    }
+
+    #[inline]
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> SizeHint {
+        self.hint.clone()
+    }
+}
 
 /// Wrapper for Axum body that makes it `Sync` to be usable with Request.
 /// TODO find a better way?

--- a/src/http/proxy.rs
+++ b/src/http/proxy.rs
@@ -31,9 +31,11 @@ pub async fn proxy(
     let response = http_client.execute(request).await?;
 
     // Convert Reqwest response into Axum one
+    // Save the body size if one is available
     let content_length = response.content_length();
     let response: http::Response<_> = response.into();
     let (parts, body) = response.into_parts();
+    // Use HintBody to override the unknown body size to the correct one
     let body = HintBody::new(body, content_length);
 
     Ok(Response::from_parts(parts, Body::new(body)))

--- a/src/http/proxy.rs
+++ b/src/http/proxy.rs
@@ -3,7 +3,11 @@ use std::sync::Arc;
 use axum::{body::Body, extract::Request, response::Response};
 use url::Url;
 
-use super::{body::SyncBodyDataStream, headers::strip_connection_headers, Client, Error};
+use super::{
+    body::{HintBody, SyncBody},
+    headers::strip_connection_headers,
+    Client, Error,
+};
 
 /// Proxies provided Axum request to a given URL using Client trait object and returns Axum response
 pub async fn proxy(
@@ -20,20 +24,52 @@ pub async fn proxy(
     let mut request = reqwest::Request::new(parts.method.clone(), url);
     *request.headers_mut() = parts.headers;
 
-    // Use SyncBodyDataStream wrapper that is Sync (Axum body is !Sync)
-    *request.body_mut() = Some(reqwest::Body::wrap_stream(SyncBodyDataStream::new(body)));
+    // Use SyncBody wrapper that is Sync (Axum body is !Sync)
+    *request.body_mut() = Some(reqwest::Body::wrap(SyncBody::new(body)));
 
     // Execute the request
     let response = http_client.execute(request).await?;
-    let headers = response.headers().clone();
 
-    // Convert the Reqwest response back to the Axum one
-    let mut response = Response::builder()
-        .status(response.status())
-        .body(Body::from_stream(response.bytes_stream()))?;
+    // Convert Reqwest response into Axum one
+    let content_length = response.content_length();
+    let response: http::Response<_> = response.into();
+    let (parts, body) = response.into_parts();
+    let body = HintBody::new(body, content_length);
 
-    // Assign the headers
-    *response.headers_mut() = headers;
+    Ok(Response::from_parts(parts, Body::new(body)))
+}
 
-    Ok(response)
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use axum::{body::Body, extract::Request};
+    use http_body::Body as _;
+
+    use crate::http::proxy::proxy;
+
+    #[derive(Debug)]
+    struct HttpClient;
+
+    #[async_trait::async_trait]
+    impl crate::http::Client for HttpClient {
+        async fn execute(&self, _: reqwest::Request) -> Result<reqwest::Response, reqwest::Error> {
+            Ok(reqwest::Response::from(
+                http::response::Builder::new()
+                    .status(200)
+                    .body(reqwest::Body::from("foobarbaz"))
+                    .unwrap(),
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_size_hint() {
+        let cli = Arc::new(HttpClient) as Arc<dyn crate::http::Client>;
+        let url = url::Url::parse("http://foo.bar").unwrap();
+        let request = Request::new(Body::empty());
+        let resp = proxy(url, request, &cli).await.unwrap();
+
+        assert_eq!(resp.body().size_hint().exact(), Some(9));
+    }
 }


### PR DESCRIPTION
When `reqwest::Response` gets converted into `http::Response` then the size hint information of the body is lost for some reason.

For now the workaround is implemented using new `HintBody` wrapper that uses the previously known size instead of the incorrect one that the inner body provides.

Also the test is added that makes sure the size hint passes through proxying.

The bug I've reported here, let's see if it helps: https://github.com/seanmonstar/reqwest/issues/2497