### PR TITLE
remove workaround, drop HintBody, update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ prost = "0.13.3"
 prost-types = "0.13.3"
 rand = "0.8.5"
 rcgen = "0.13.1"
-reqwest = { version = "0.12.9", default-features = false, features = [
+reqwest = { version = "0.12.12", default-features = false, features = [
     "http2",
     "rustls-tls",
     "hickory-dns",

--- a/src/http/headers.rs
+++ b/src/http/headers.rs
@@ -54,7 +54,7 @@ pub fn strip_connection_headers(headers: &mut HeaderMap) {
     // TE is forbidden unless it's "trailers"
     if headers
         .get(TE)
-        .map_or(false, |te_header| te_header != "trailers")
+        .is_some_and(|te_header| te_header != "trailers")
     {
         headers.remove(TE);
     }

--- a/src/http/proxy.rs
+++ b/src/http/proxy.rs
@@ -3,11 +3,7 @@ use std::sync::Arc;
 use axum::{body::Body, extract::Request, response::Response};
 use url::Url;
 
-use super::{
-    body::{HintBody, SyncBody},
-    headers::strip_connection_headers,
-    Client, Error,
-};
+use super::{body::SyncBody, headers::strip_connection_headers, Client, Error};
 
 /// Proxies provided Axum request to a given URL using Client trait object and returns Axum response
 pub async fn proxy(
@@ -32,11 +28,8 @@ pub async fn proxy(
 
     // Convert Reqwest response into Axum one
     // Save the body size if one is available
-    let content_length = response.content_length();
     let response: http::Response<_> = response.into();
     let (parts, body) = response.into_parts();
-    // Use HintBody to override the unknown body size to the correct one
-    let body = HintBody::new(body, content_length);
 
     Ok(Response::from_parts(parts, Body::new(body)))
 }


### PR DESCRIPTION
The size_hint was fixed in reqwest 0.12.10 so we don't need HintBody anymore.

Also update deps