### PR TITLE
Add `Cache-Control` handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ axum = "0.8.1"
 backoff = { version = "0.4.0", features = ["tokio"], optional = true }
 base64 = "0.22.1"
 bytes = "1.10.0"
+candid = "0.10.10"
 clap = { version = "4.5.20", features = ["derive", "string", "env"] }
 chacha20poly1305 = "0.10.1"
 cloudflare = { version = "0.13.0", default-features = false, features = [

--- a/src/http/headers.rs
+++ b/src/http/headers.rs
@@ -23,6 +23,7 @@ pub const X_IC_ERROR_CAUSE: HeaderName = HeaderName::from_static("x-ic-error-cau
 pub const X_IC_REQUEST_TYPE: HeaderName = HeaderName::from_static("x-ic-request-type");
 pub const X_IC_CANISTER_ID: HeaderName = HeaderName::from_static("x-ic-canister-id");
 pub const X_IC_COUNTRY_CODE: HeaderName = HeaderName::from_static("x-ic-country-code");
+pub const X_CACHE_TTL: HeaderName = HeaderName::from_static("x-cache-ttl");
 pub const X_REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
 pub const X_REQUESTED_WITH: HeaderName = HeaderName::from_static("x-requested-with");
 pub const X_REAL_IP: HeaderName = HeaderName::from_static("x-real-ip");

--- a/src/http/headers.rs
+++ b/src/http/headers.rs
@@ -8,39 +8,47 @@ use http::header::{
     CONNECTION, HeaderMap, HeaderName, HeaderValue, TE, TRANSFER_ENCODING, UPGRADE,
 };
 
+#[macro_export]
+macro_rules! hname {
+    ($id:expr) => {{ http::header::HeaderName::from_static($id) }};
+}
+
+#[macro_export]
+macro_rules! hval {
+    ($id:expr) => {{ http::header::HeaderValue::from_static($id) }};
+}
+
 // Header names
-pub const X_IC_CACHE_STATUS: HeaderName = HeaderName::from_static("x-ic-cache-status");
-pub const X_IC_CACHE_BYPASS_REASON: HeaderName =
-    HeaderName::from_static("x-ic-cache-bypass-reason");
-pub const X_IC_SUBNET_ID: HeaderName = HeaderName::from_static("x-ic-subnet-id");
-pub const X_IC_NODE_ID: HeaderName = HeaderName::from_static("x-ic-node-id");
-pub const X_IC_SUBNET_TYPE: HeaderName = HeaderName::from_static("x-ic-subnet-type");
-pub const X_IC_CANISTER_ID_CBOR: HeaderName = HeaderName::from_static("x-ic-canister-id-cbor");
-pub const X_IC_METHOD_NAME: HeaderName = HeaderName::from_static("x-ic-method-name");
-pub const X_IC_SENDER: HeaderName = HeaderName::from_static("x-ic-sender");
-pub const X_IC_RETRIES: HeaderName = HeaderName::from_static("x-ic-retries");
-pub const X_IC_ERROR_CAUSE: HeaderName = HeaderName::from_static("x-ic-error-cause");
-pub const X_IC_REQUEST_TYPE: HeaderName = HeaderName::from_static("x-ic-request-type");
-pub const X_IC_CANISTER_ID: HeaderName = HeaderName::from_static("x-ic-canister-id");
-pub const X_IC_COUNTRY_CODE: HeaderName = HeaderName::from_static("x-ic-country-code");
-pub const X_CACHE_TTL: HeaderName = HeaderName::from_static("x-cache-ttl");
-pub const X_REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
-pub const X_REQUESTED_WITH: HeaderName = HeaderName::from_static("x-requested-with");
-pub const X_REAL_IP: HeaderName = HeaderName::from_static("x-real-ip");
+pub const X_IC_CACHE_STATUS: HeaderName = hname!("x-ic-cache-status");
+pub const X_IC_CACHE_BYPASS_REASON: HeaderName = hname!("x-ic-cache-bypass-reason");
+pub const X_IC_SUBNET_ID: HeaderName = hname!("x-ic-subnet-id");
+pub const X_IC_NODE_ID: HeaderName = hname!("x-ic-node-id");
+pub const X_IC_SUBNET_TYPE: HeaderName = hname!("x-ic-subnet-type");
+pub const X_IC_CANISTER_ID_CBOR: HeaderName = hname!("x-ic-canister-id-cbor");
+pub const X_IC_METHOD_NAME: HeaderName = hname!("x-ic-method-name");
+pub const X_IC_SENDER: HeaderName = hname!("x-ic-sender");
+pub const X_IC_RETRIES: HeaderName = hname!("x-ic-retries");
+pub const X_IC_ERROR_CAUSE: HeaderName = hname!("x-ic-error-cause");
+pub const X_IC_REQUEST_TYPE: HeaderName = hname!("x-ic-request-type");
+pub const X_IC_CANISTER_ID: HeaderName = hname!("x-ic-canister-id");
+pub const X_IC_COUNTRY_CODE: HeaderName = hname!("x-ic-country-code");
+pub const X_CACHE_TTL: HeaderName = hname!("x-cache-ttl");
+pub const X_REQUEST_ID: HeaderName = hname!("x-request-id");
+pub const X_REQUESTED_WITH: HeaderName = hname!("x-requested-with");
+pub const X_REAL_IP: HeaderName = hname!("x-real-ip");
 
 // Header values
-pub const CONTENT_TYPE_CBOR: HeaderValue = HeaderValue::from_static("application/cbor");
-pub const CONTENT_TYPE_OCTET_STREAM: HeaderValue =
-    HeaderValue::from_static("application/octet-stream");
-pub const CONTENT_TYPE_HTML: HeaderValue = HeaderValue::from_static("text/html; charset=utf-8");
-pub const HSTS_1YEAR: HeaderValue = HeaderValue::from_static("max-age=31536000; includeSubDomains");
-pub const X_CONTENT_TYPE_OPTIONS_NO_SNIFF: HeaderValue = HeaderValue::from_static("nosniff");
-pub const X_FRAME_OPTIONS_DENY: HeaderValue = HeaderValue::from_static("DENY");
+pub const CONTENT_TYPE_CBOR: HeaderValue = hval!("application/cbor");
+pub const CONTENT_TYPE_OCTET_STREAM: HeaderValue = hval!("application/octet-stream");
+pub const CONTENT_TYPE_HTML: HeaderValue = hval!("text/html; charset=utf-8");
+pub const HSTS_1YEAR: HeaderValue = hval!("max-age=31536000; includeSubDomains");
+pub const X_CONTENT_TYPE_OPTIONS_NO_SNIFF: HeaderValue = hval!("nosniff");
+pub const X_FRAME_OPTIONS_DENY: HeaderValue = hval!("DENY");
 
 static CONNECTION_HEADERS: [HeaderName; 5] = [
-    HeaderName::from_static("keep-alive"),
-    HeaderName::from_static("proxy-connection"),
-    HeaderName::from_static("http2-settings"),
+    hname!("keep-alive"),
+    hname!("proxy-connection"),
+    hname!("http2-settings"),
     TRANSFER_ENCODING,
     UPGRADE,
 ];

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -198,7 +198,9 @@ impl<T: AsyncRead + AsyncWrite + Send + Sync + Unpin> AsyncWrite for AsyncCounte
 
 #[cfg(test)]
 mod test {
-    use http::{HeaderValue, Uri, header::HOST};
+    use http::{Uri, header::HOST};
+
+    use crate::hval;
 
     use super::*;
 
@@ -252,7 +254,7 @@ mod test {
             .path_and_query("/foo?bar=baz")
             .build()
             .unwrap();
-        (*req.headers_mut()).insert(HOST, HeaderValue::from_static("foo.baz"));
+        (*req.headers_mut()).insert(HOST, hval!("foo.baz"));
         assert_eq!(extract_authority(&req), Some("foo.baz"));
 
         // Both: authority should take precedence (not a real world use case probably)
@@ -263,7 +265,7 @@ mod test {
             .path_and_query("/foo?bar=baz")
             .build()
             .unwrap();
-        (*req.headers_mut()).insert(HOST, HeaderValue::from_static("foo.baz"));
+        (*req.headers_mut()).insert(HOST, hval!("foo.baz"));
         assert_eq!(extract_authority(&req), Some("foo.bar"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,3 +34,8 @@ pub fn parse_size_decimal(s: &str) -> Result<u64, parse_size::Error> {
 pub fn parse_size_decimal_usize(s: &str) -> Result<usize, parse_size::Error> {
     parse_size(s).map(|x| x as usize)
 }
+
+#[macro_export]
+macro_rules! principal {
+    ($id:expr) => {{ candid::Principal::from_text($id).unwrap() }};
+}


### PR DESCRIPTION
* Respect `no-cache` and `no-store` (we treat them equally) to avoid caching
* Respect `max-age=N` to set a per-entry TTL (with a cap - `max_ttl` option)
* Add `x-cache-ttl` header that indicates for how long did we cache the response
* Add `CacheBuilder` for easier cache usage
* Add more metrics
* Some code optimizations (less calls to `Instant::now()` etc)
* Add some macros (`hval`, `hname`, `principal`)
* Fix flaky test