### PR TITLE
chore(BOUN-1470): upgrade `instant-acme`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,4 +162,4 @@ required-features = ["vector"]
 
 [package.metadata.cargo-all-features]
 # Limit feature combinations to reduce test duration
-max_combination_size = 3
+max_combination_size = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ ic-agent = { git = "https://github.com/dfinity/agent-rs", rev = "f34acedb5539838
     "_internal_dynamic-routing",
 ] }
 indoc = "2.0.6"
-instant-acme = { version = "0.7.2", default-features = false, features = [
+instant-acme = { version = "0.8.2", default-features = false, features = [
     "ring",
     "hyper-rustls",
 ], optional = true }

--- a/src/http/client/cli.rs
+++ b/src/http/client/cli.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 use clap::Args;
 use humantime::parse_duration;
 
+use crate::http::client::HttpVersion;
+
 #[derive(Args, Clone, Debug, Eq, PartialEq)]
 pub struct HttpClient {
     /// Timeout for HTTP connection phase
@@ -34,9 +36,10 @@ pub struct HttpClient {
     #[clap(env, long, default_value = "5s", value_parser = parse_duration)]
     pub http_client_http2_keepalive_timeout: Duration,
 
-    /// HTTP2 Only. Disables HTTP/1.1
-    #[clap(env, long)]
-    pub http_client_http2_only: bool,
+    /// Which HTTP versions to use.
+    /// Can be "http1", "http2" or "all". Defaults to "all".
+    #[clap(env, long, default_value = "all")]
+    pub http_client_http_version: HttpVersion,
 
     /// Fixed name to use when checking TLS certificates, instead of the host name.
     #[clap(env, long)]
@@ -55,7 +58,7 @@ impl From<&HttpClient> for super::Options {
             http2_keepalive: Some(c.http_client_http2_keepalive),
             http2_keepalive_timeout: c.http_client_http2_keepalive_timeout,
             http2_keepalive_idle: false,
-            http2_only: c.http_client_http2_only,
+            http_version: c.http_client_http_version,
             user_agent: "".into(),
             tls_config: None,
             tls_fixed_name: c.http_client_tls_fixed_name.clone(),

--- a/src/http/client/clients_reqwest.rs
+++ b/src/http/client/clients_reqwest.rs
@@ -15,7 +15,7 @@ use reqwest::{Request, Response};
 use scopeguard::defer;
 use url::Url;
 
-use crate::http::dns::CloneableDnsResolver;
+use crate::http::{client::HttpVersion, dns::CloneableDnsResolver};
 
 use super::{Client, ClientStats, ClientWithStats, Error, Metrics, Options, Stats};
 
@@ -49,8 +49,14 @@ pub fn new<R: CloneableDnsResolver>(
         .redirect(reqwest::redirect::Policy::none())
         .no_proxy();
 
-    if opts.http2_only {
-        client = client.http2_prior_knowledge();
+    match opts.http_version {
+        HttpVersion::Http1 => {
+            client = client.http1_only();
+        }
+        HttpVersion::Http2 => {
+            client = client.http2_prior_knowledge();
+        }
+        _ => {}
     }
 
     if let Some(v) = opts.pool_idle_max {

--- a/src/http/client/mod.rs
+++ b/src/http/client/mod.rs
@@ -13,6 +13,7 @@ use prometheus::{
     register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry,
 };
 use reqwest::{Request, Response};
+use strum::{Display, EnumString};
 
 use super::Error;
 
@@ -83,6 +84,14 @@ impl Metrics {
     }
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Display, EnumString)]
+#[strum(serialize_all = "snake_case")]
+pub enum HttpVersion {
+    Http1,
+    Http2,
+    All,
+}
+
 /// HTTP client options
 #[derive(Debug, Clone)]
 pub struct Options {
@@ -95,7 +104,7 @@ pub struct Options {
     pub http2_keepalive: Option<Duration>,
     pub http2_keepalive_timeout: Duration,
     pub http2_keepalive_idle: bool,
-    pub http2_only: bool,
+    pub http_version: HttpVersion,
     pub user_agent: String,
     pub tls_config: Option<rustls::ClientConfig>,
     pub tls_fixed_name: Option<String>,
@@ -113,7 +122,7 @@ impl Default for Options {
             http2_keepalive: None,
             http2_keepalive_timeout: Duration::from_secs(30),
             http2_keepalive_idle: false,
-            http2_only: false,
+            http_version: HttpVersion::All,
             user_agent: "Crab".into(),
             tls_config: None,
             tls_fixed_name: None,

--- a/src/tls/acme/client.rs
+++ b/src/tls/acme/client.rs
@@ -118,13 +118,13 @@ impl HttpClientTrait for HttpClient {
     fn request(
         &self,
         req: Request<BodyWrapper<Bytes>>,
-    ) -> Pin<Box<dyn Future<Output = Result<BytesResponse, instant_acme::Error>> + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<BytesResponse, AcmeError>> + Send>> {
         let fut = self.0.request(req);
 
         Box::pin(async move {
             match fut.await {
                 Ok(rsp) => Ok(BytesResponse::from(rsp)),
-                Err(e) => Err(instant_acme::Error::Other(Box::new(e))),
+                Err(e) => Err(AcmeError::Other(Box::new(e))),
             }
         })
     }


### PR DESCRIPTION
* This upgrades `instant-acme` crate from `0.7.2` to `0.8.2` which has breaking changes. That simplifies order polling and makes our client simpler a bit. Pebble ACME tests pass fine.

* Additionally add `http_client_http_version` CLI option to HTTP clients to allow to force them to use specific HTTP version