### PR TITLE
feat(BOUN-1449): add Web Application Firewall middleware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ prost = { version = "0.14.1", optional = true }
 prost-types = { version = "0.14.1", optional = true }
 rand = { version = "=0.8.5", features = ["small_rng"] }
 rcgen = { version = "0.14.3", optional = true }
+regex = "1.11.2"
 reqwest = { version = "0.12.12", default-features = false, features = [
     "blocking",
     "http2",
@@ -114,9 +115,10 @@ rustls-platform-verifier = "0.6.0"
 scopeguard = "1.2.0"
 serde = { version = "1.0.214", features = ["derive"] }
 serde_json = "1.0.132"
+serde_with = "3.14.0"
+sev = { version = "6.1.0", optional = true }
 sha1 = "0.10.6"
 sha2 = { version = "0.10.9", optional = true }
-sev = { version = "6.1.0", optional = true }
 strum = { version = "0.27.1", features = ["derive"] }
 strum_macros = "0.27.1"
 systemstat = "0.2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ scopeguard = "1.2.0"
 serde = { version = "1.0.214", features = ["derive"] }
 serde_json = "1.0.132"
 serde_with = "3.14.0"
+serde_yaml_ng = "0.10"
 sev = { version = "6.1.0", optional = true }
 sha1 = "0.10.6"
 sha2 = { version = "0.10.9", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ flate2 = { version = "1.0", optional = true }
 fqdn = { version = "0.4.1", features = ["serde"] }
 futures = "0.3.31"
 futures-util = "0.3.31"
-governor = "0.8.0" # must match tower-governor deps
+governor = "0.10.0" # must match tower-governor deps
 hex = { version = "0.4.3", optional = true }
 hickory-proto = "0.25.1"
 hickory-resolver = { version = "0.25.1", features = [
@@ -134,7 +134,7 @@ tokio-rustls = { version = "0.26.0", default-features = false, features = [
 ] }
 tokio-io-timeout = "1.2.0"
 tower = { version = "0.5.1", features = ["util"] }
-tower_governor = { version = "0.7" }
+tower_governor = { version = "0.8" }
 tower-service = "0.3.3"
 tracing = "0.1.40"
 url = "2.5.3"

--- a/src/http/middleware/mod.rs
+++ b/src/http/middleware/mod.rs
@@ -1,1 +1,2 @@
 pub mod rate_limiter;
+pub mod waf;

--- a/src/http/middleware/mod.rs
+++ b/src/http/middleware/mod.rs
@@ -1,2 +1,23 @@
+use std::{net::IpAddr, str::FromStr, sync::Arc};
+
+use http::Request;
+
+use crate::http::{ConnInfo, headers::X_REAL_IP};
+
 pub mod rate_limiter;
 pub mod waf;
+
+/// Extracts IP address from `x-real-ip` header or ConnInfo extension
+pub fn extract_ip_from_request<B>(req: &Request<B>) -> Option<IpAddr> {
+    // Try to extract from the header first
+    req.headers()
+        .get(X_REAL_IP)
+        .and_then(|x| x.to_str().ok())
+        .and_then(|x| IpAddr::from_str(x).ok())
+        .or_else(|| {
+            // Then, if that failed, from the ConnInfo extension
+            req.extensions()
+                .get::<Arc<ConnInfo>>()
+                .map(|x| x.remote_addr.ip())
+        })
+}

--- a/src/http/middleware/mod.rs
+++ b/src/http/middleware/mod.rs
@@ -57,5 +57,9 @@ mod test {
             .body("")
             .unwrap();
         assert_eq!(extract_ip_from_request(&req), Some(addr2));
+
+        // Neither
+        let req = Request::builder().body("").unwrap();
+        assert_eq!(extract_ip_from_request(&req), None);
     }
 }

--- a/src/http/middleware/rate_limiter.rs
+++ b/src/http/middleware/rate_limiter.rs
@@ -1,8 +1,8 @@
-use std::{net::IpAddr, sync::Arc, time::Duration};
+use std::{net::IpAddr, str::FromStr, sync::Arc, time::Duration};
 
 use ::governor::{clock::QuantaInstant, middleware::NoOpMiddleware};
 use anyhow::{Error, anyhow};
-use axum::{extract::Request, response::IntoResponse};
+use axum::{body::Body, extract::Request, response::IntoResponse};
 use http::StatusCode;
 use tower_governor::{
     GovernorError, GovernorLayer,
@@ -10,7 +10,9 @@ use tower_governor::{
     key_extractor::{GlobalKeyExtractor, KeyExtractor},
 };
 
-use crate::http::ConnInfo;
+use crate::http::{ConnInfo, headers::X_REAL_IP};
+
+pub type RateLimitLayer<K> = GovernorLayer<K, NoOpMiddleware<QuantaInstant>, Body>;
 
 #[derive(Clone)]
 pub struct IpKeyExtractor;
@@ -19,10 +21,18 @@ impl KeyExtractor for IpKeyExtractor {
     type Key = IpAddr;
 
     fn extract<B>(&self, req: &Request<B>) -> Result<Self::Key, GovernorError> {
-        // ConnInfo is expected to exist in request extension, otherwise 500.
-        req.extensions()
-            .get::<Arc<ConnInfo>>()
-            .map(|x| x.remote_addr.ip())
+        // Try to extract from the header first
+        req.headers()
+            .get(X_REAL_IP)
+            .and_then(|x| x.to_str().ok())
+            .and_then(|x| IpAddr::from_str(x).ok())
+            .or_else(|| {
+                // Then from the extension
+                // ConnInfo is expected to exist in request extension
+                req.extensions()
+                    .get::<Arc<ConnInfo>>()
+                    .map(|x| x.remote_addr.ip())
+            })
             .ok_or(GovernorError::UnableToExtractKey)
     }
 }
@@ -31,7 +41,7 @@ pub fn layer_global<R: IntoResponse + Clone + Send + Sync + 'static>(
     rps: u32,
     burst_size: u32,
     rate_limited_response: R,
-) -> Result<GovernorLayer<GlobalKeyExtractor, NoOpMiddleware<QuantaInstant>>, Error> {
+) -> Result<RateLimitLayer<GlobalKeyExtractor>, Error> {
     layer(rps, burst_size, GlobalKeyExtractor, rate_limited_response)
 }
 
@@ -39,16 +49,16 @@ pub fn layer_by_ip<R: IntoResponse + Clone + Send + Sync + 'static>(
     rps: u32,
     burst_size: u32,
     rate_limited_response: R,
-) -> Result<GovernorLayer<IpKeyExtractor, NoOpMiddleware<QuantaInstant>>, Error> {
+) -> Result<RateLimitLayer<IpKeyExtractor>, Error> {
     layer(rps, burst_size, IpKeyExtractor, rate_limited_response)
 }
 
-pub fn layer<T: KeyExtractor, R: IntoResponse + Clone + Send + Sync + 'static>(
+pub fn layer<K: KeyExtractor, R: IntoResponse + Clone + Send + Sync + 'static>(
     rps: u32,
     burst_size: u32,
-    key_extractor: T,
+    key_extractor: K,
     rate_limited_response: R,
-) -> Result<GovernorLayer<T, NoOpMiddleware<QuantaInstant>>, Error> {
+) -> Result<RateLimitLayer<K>, Error> {
     let period = Duration::from_secs(1)
         .checked_div(rps)
         .ok_or_else(|| anyhow!("RPS is zero"))?;
@@ -56,22 +66,29 @@ pub fn layer<T: KeyExtractor, R: IntoResponse + Clone + Send + Sync + 'static>(
     let config = Arc::new(
         GovernorConfigBuilder::default()
             .period(period)
-            .error_handler(move |err| match err {
-                GovernorError::TooManyRequests { .. } => {
-                    rate_limited_response.clone().into_response()
-                }
-                GovernorError::UnableToExtractKey => {
-                    (StatusCode::INTERNAL_SERVER_ERROR, "Unable to extract rate limiting key").into_response()
-                }
-                GovernorError::Other { code, msg, headers } => {
-                    (StatusCode::INTERNAL_SERVER_ERROR, format!("Rate limiter failed unexpectedly: code={code}, msg={msg:?}, headers={headers:?}")).into_response()
-                }
-            })
             .burst_size(burst_size)
             .key_extractor(key_extractor)
-            .finish().ok_or_else(|| anyhow!("unable to build governor config"))?);
+            .finish()
+            .ok_or_else(|| anyhow!("unable to build governor config"))?,
+    );
 
-    Ok(GovernorLayer { config })
+    let layer = GovernorLayer::new(config).error_handler(move |err| match err {
+        GovernorError::TooManyRequests { .. } => rate_limited_response.clone().into_response(),
+        GovernorError::UnableToExtractKey => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Unable to extract rate limiting key",
+        )
+            .into_response(),
+        GovernorError::Other { code, msg, headers } => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!(
+                "Rate limiter failed unexpectedly: code={code}, msg={msg:?}, headers={headers:?}"
+            ),
+        )
+            .into_response(),
+    });
+
+    Ok(layer)
 }
 
 #[cfg(test)]

--- a/src/http/middleware/waf.rs
+++ b/src/http/middleware/waf.rs
@@ -673,10 +673,11 @@ async fn api_handler(State(state): State<WafLayer>, body: Bytes) -> AxumResponse
         }
     };
 
+    warn!("WAF: Ruleset updated over API");
     if state.set_ruleset(ruleset) {
-        "Ruleset updated"
+        "Ruleset updated\n"
     } else {
-        "Ruleset is the same, not updated"
+        "Ruleset is the same, not updated\n"
     }
     .into_response()
 }

--- a/src/http/middleware/waf.rs
+++ b/src/http/middleware/waf.rs
@@ -1,11 +1,21 @@
-use std::str::FromStr;
+use std::{net::IpAddr, num::NonZeroU32, str::FromStr, time::Duration};
 
+use ahash::RandomState;
 use anyhow::{Context, anyhow};
-use http::{HeaderMap, HeaderName, HeaderValue, Method, Request, Response, StatusCode};
+use axum::response::{IntoResponse, Response};
+use governor::{
+    Quota, RateLimiter,
+    clock::{Clock, DefaultClock},
+    state::{InMemoryState, NotKeyed, keyed::DashMapStateStore},
+};
+use http::{HeaderMap, HeaderName, HeaderValue, Method, Request, StatusCode, header::RETRY_AFTER};
+use humantime::parse_duration;
 use itertools::Itertools;
 use regex::Regex;
 use serde::Deserialize;
 use serde_with::{DeserializeFromStr, DisplayFromStr, serde_as};
+
+use crate::http::{Error, middleware::extract_ip_from_request};
 
 /// Matches HTTP status codes or ranges
 #[derive(Debug, Clone, Copy, Eq, PartialEq, DeserializeFromStr)]
@@ -15,7 +25,7 @@ pub struct StatusRange {
 }
 
 impl StatusRange {
-    pub const fn check(&self, v: StatusCode) -> bool {
+    pub const fn evaluate(&self, v: StatusCode) -> bool {
         let code = v.as_u16();
 
         if let Some(to) = self.to {
@@ -67,6 +77,7 @@ pub struct HeaderMatcher {
     #[serde_as(as = "DisplayFromStr")]
     pub name: HeaderName,
     #[serde_as(as = "DisplayFromStr")]
+    #[serde(alias = "value")]
     pub regex: Regex,
 }
 
@@ -78,7 +89,7 @@ impl PartialEq for HeaderMatcher {
 impl Eq for HeaderMatcher {}
 
 impl HeaderMatcher {
-    pub fn check(&self, name: &HeaderName, value: &HeaderValue) -> bool {
+    pub fn evaluate(&self, name: &HeaderName, value: &HeaderValue) -> bool {
         if name != self.name {
             return false;
         }
@@ -90,8 +101,8 @@ impl HeaderMatcher {
         self.regex.is_match(value)
     }
 
-    pub fn check_headermap(&self, map: &HeaderMap) -> bool {
-        map.iter().any(|(name, value)| self.check(name, value))
+    pub fn evaluate_headermap(&self, map: &HeaderMap) -> bool {
+        map.iter().any(|(name, value)| self.evaluate(name, value))
     }
 }
 
@@ -116,7 +127,7 @@ impl PartialEq for RequestMatcher {
 impl Eq for RequestMatcher {}
 
 impl RequestMatcher {
-    pub fn check<T>(&self, req: &Request<T>) -> bool {
+    pub fn evaluate<T>(&self, req: &Request<T>) -> bool {
         // Check if URL matches
         if let Some(v) = &self.url {
             if !v.is_match(&req.uri().to_string()) {
@@ -133,7 +144,7 @@ impl RequestMatcher {
 
         // Check that all of header rules match
         if let Some(v) = &self.headers {
-            if !v.iter().all(|rule| rule.check_headermap(req.headers())) {
+            if !v.iter().all(|rule| rule.evaluate_headermap(req.headers())) {
                 return false;
             }
         }
@@ -152,23 +163,294 @@ pub struct ResponseMatcher {
 }
 
 impl ResponseMatcher {
-    pub fn check<T>(&self, req: &Response<T>) -> bool {
+    pub fn evaluate<T>(&self, req: &Response<T>) -> bool {
         // Check status codes
         if let Some(v) = &self.status {
-            if !v.iter().any(|x| x.check(req.status())) {
+            if !v.iter().any(|x| x.evaluate(req.status())) {
                 return false;
             }
         }
 
         // Check that all of header rules match
         if let Some(v) = &self.headers {
-            if !v.iter().all(|rule| rule.check_headermap(req.headers())) {
+            if !v.iter().all(|rule| rule.evaluate_headermap(req.headers())) {
                 return false;
             }
         }
 
         // Empty rule matches anything
         true
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum RateLimitDecision {
+    Pass,
+    Throttle(Duration),
+}
+
+/// Type of the rate limiting applied
+#[derive(Debug)]
+pub enum RateLimitType {
+    Global(Quota, RateLimiter<NotKeyed, InMemoryState, DefaultClock>),
+    PerIp(
+        Quota,
+        RateLimiter<IpAddr, DashMapStateStore<IpAddr, RandomState>, DefaultClock>,
+    ),
+}
+
+impl FromStr for RateLimitType {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let Some((typ, limit)) = s.split_once(':') else {
+            return Err(anyhow!("expecting limit in 'type:rate' format").into());
+        };
+
+        let Some((rate, dur)) = limit.split_once("/") else {
+            return Err(anyhow!("expecting rate in 'rate/duration' format").into());
+        };
+
+        let rate = rate.parse::<u32>().context("unable to parse rate as u32")?;
+        let dur = parse_duration(dur).context("unable to parse duration")?;
+
+        if rate == 0 {
+            return Err(anyhow!("rate must be > 0").into());
+        }
+
+        if dur == Duration::ZERO {
+            return Err(anyhow!("duration cannot be zero").into());
+        }
+
+        // We already checked that rate is > 0
+        let replenish_period = dur / rate;
+        let quota = Quota::with_period(replenish_period)
+            .unwrap()
+            .allow_burst(NonZeroU32::new(rate).unwrap());
+
+        Ok(match typ {
+            "global" => Self::Global(quota, RateLimiter::direct(quota)),
+            "per_ip" => Self::PerIp(
+                quota,
+                RateLimiter::dashmap_with_hasher(quota, RandomState::new()),
+            ),
+            _ => return Err(anyhow!("unknown rate limiter type {typ}").into()),
+        })
+    }
+}
+
+impl PartialEq for RateLimitType {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Global(q1, _), Self::Global(q2, _)) => q1 == q2,
+            (Self::PerIp(q1, _), Self::PerIp(q2, _)) => q1 == q2,
+            _ => false,
+        }
+    }
+}
+impl Eq for RateLimitType {}
+
+impl RateLimitType {
+    /// Evaluate the request against the rate limit
+    pub fn allowed<B>(&self, req: &Request<B>) -> RateLimitDecision {
+        let (clock, r) = match self {
+            Self::Global(_, v) => (v.clock(), v.check()),
+            Self::PerIp(_, v) => {
+                // Allow if we fail to extract IP.
+                // It shouldn't happen ever under normal workload
+                // and it's probably better to allow the request in this case.
+                let Some(ip) = extract_ip_from_request(req) else {
+                    return RateLimitDecision::Pass;
+                };
+
+                (v.clock(), v.check_key(&ip))
+            }
+        };
+
+        if let Err(e) = r {
+            let dur = e.wait_time_from(clock.now());
+            return RateLimitDecision::Throttle(dur);
+        }
+
+        RateLimitDecision::Pass
+    }
+}
+
+/// Action that applies to the requests
+#[derive(Debug, PartialEq, Eq)]
+pub enum RequestAction {
+    Pass,
+    Block(StatusCode),
+    RateLimit(RateLimitType),
+}
+
+impl FromStr for RequestAction {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "pass" {
+            return Ok(Self::Pass);
+        }
+
+        let mut it = s.split(':');
+        let (pfx, sfx) = (it.next().unwrap(), it.next());
+        if pfx == "block" {
+            let code = if let Some(code) = sfx {
+                StatusCode::from_str(code).context("unable to parse status code")?
+            } else {
+                StatusCode::FORBIDDEN
+            };
+
+            return Ok(Self::Block(code));
+        }
+
+        if pfx == "limit" {
+            let Some((_, v)) = s.split_once(':') else {
+                return Err(anyhow!("expecting limit definition after ':'").into());
+            };
+
+            return Ok(Self::RateLimit(RateLimitType::from_str(v)?));
+        }
+
+        Err(anyhow!("unsupported action format").into())
+    }
+}
+
+/// Action that applies to the responses
+#[derive(Debug, PartialEq, Eq)]
+pub enum ResponseAction {
+    Pass,
+    Block(StatusCode),
+}
+
+impl FromStr for ResponseAction {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "pass" {
+            return Ok(Self::Pass);
+        }
+
+        let mut it = s.split(':');
+        let (pfx, sfx) = (it.next().unwrap(), it.next());
+        if pfx == "block" {
+            let code = if let Some(code) = sfx {
+                StatusCode::from_str(code).context("unable to parse status code")?
+            } else {
+                StatusCode::FORBIDDEN
+            };
+
+            return Ok(Self::Block(code));
+        }
+
+        Err(anyhow!("unsupported action format").into())
+    }
+}
+
+/// Outcome of the rule evaluation
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Decision {
+    Pass,
+    Block(StatusCode),
+    Throttle(Duration),
+}
+
+impl IntoResponse for Decision {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Pass => StatusCode::OK.into_response(),
+            Self::Block(v) => (v, "Blocked for policy reasons").into_response(),
+            Self::Throttle(v) => (
+                StatusCode::TOO_MANY_REQUESTS,
+                [(
+                    RETRY_AFTER,
+                    HeaderValue::from_str(&v.as_secs().to_string()).unwrap(),
+                )],
+                "Rate limited",
+            )
+                .into_response(),
+        }
+    }
+}
+
+/// Request rule
+#[serde_as]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+pub struct RequestRule {
+    #[serde(alias = "rule")]
+    pub matcher: RequestMatcher,
+    #[serde_as(as = "DisplayFromStr")]
+    pub action: RequestAction,
+}
+
+impl RequestRule {
+    pub fn evaluate<B>(&self, req: &Request<B>) -> Option<Decision> {
+        if !self.matcher.evaluate(req) {
+            return None;
+        }
+
+        Some(match &self.action {
+            RequestAction::Pass => Decision::Pass,
+            RequestAction::Block(v) => Decision::Block(*v),
+            RequestAction::RateLimit(v) => match v.allowed(req) {
+                RateLimitDecision::Pass => Decision::Pass,
+                RateLimitDecision::Throttle(v) => Decision::Throttle(v),
+            },
+        })
+    }
+}
+
+/// Response rule
+#[serde_as]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+pub struct ResponseRule {
+    #[serde(alias = "rule")]
+    pub matcher: ResponseMatcher,
+    #[serde_as(as = "DisplayFromStr")]
+    pub action: ResponseAction,
+}
+
+impl ResponseRule {
+    pub fn evaluate<B>(&self, resp: &Response<B>) -> Option<Decision> {
+        if !self.matcher.evaluate(resp) {
+            return None;
+        }
+
+        Some(match &self.action {
+            ResponseAction::Pass => Decision::Pass,
+            ResponseAction::Block(v) => Decision::Block(*v),
+        })
+    }
+}
+
+/// Ruleset
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+pub struct Ruleset {
+    pub requests: Option<Vec<RequestRule>>,
+    pub responses: Option<Vec<ResponseRule>>,
+}
+
+impl Ruleset {
+    /// Evaluate given request against ruleset
+    pub fn evaluate_request<B>(&self, req: &Request<B>) -> Decision {
+        let Some(v) = &self.requests else {
+            return Decision::Pass;
+        };
+
+        v.iter()
+            .find_map(|x| x.evaluate(req))
+            .unwrap_or(Decision::Pass)
+    }
+
+    /// Evaluate given response against ruleset
+    pub fn evaluate_response<B>(&self, resp: &Response<B>) -> Decision {
+        let Some(v) = &self.responses else {
+            return Decision::Pass;
+        };
+
+        v.iter()
+            .find_map(|x| x.evaluate(resp))
+            .unwrap_or(Decision::Pass)
     }
 }
 
@@ -207,17 +489,17 @@ mod test {
 
         let range = StatusRange::from_str("200-499").unwrap();
 
-        assert!(range.check(StatusCode::OK));
-        assert!(range.check(StatusCode::ACCEPTED));
-        assert!(range.check(StatusCode::PERMANENT_REDIRECT));
-        assert!(range.check(StatusCode::NOT_FOUND));
-        assert!(!range.check(StatusCode::CONTINUE));
-        assert!(!range.check(StatusCode::INTERNAL_SERVER_ERROR));
-        assert!(!range.check(StatusCode::SERVICE_UNAVAILABLE));
+        assert!(range.evaluate(StatusCode::OK));
+        assert!(range.evaluate(StatusCode::ACCEPTED));
+        assert!(range.evaluate(StatusCode::PERMANENT_REDIRECT));
+        assert!(range.evaluate(StatusCode::NOT_FOUND));
+        assert!(!range.evaluate(StatusCode::CONTINUE));
+        assert!(!range.evaluate(StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(!range.evaluate(StatusCode::SERVICE_UNAVAILABLE));
 
         let range = StatusRange::from_str("200").unwrap();
-        assert!(range.check(StatusCode::OK));
-        assert!(!range.check(StatusCode::ACCEPTED));
+        assert!(range.evaluate(StatusCode::OK));
+        assert!(!range.evaluate(StatusCode::ACCEPTED));
     }
 
     #[test]
@@ -265,7 +547,7 @@ mod test {
             .uri("https://lala")
             .body("")
             .unwrap();
-        assert!(rule.check(&req));
+        assert!(rule.evaluate(&req));
 
         let req = Request::builder()
             .header("foo", "barfuss")
@@ -274,7 +556,7 @@ mod test {
             .uri("https://lala")
             .body("")
             .unwrap();
-        assert!(rule.check(&req));
+        assert!(rule.evaluate(&req));
 
         // Test partial matches (no match)
         let req = Request::builder()
@@ -284,7 +566,7 @@ mod test {
             .uri("https://lala")
             .body("")
             .unwrap();
-        assert!(!rule.check(&req));
+        assert!(!rule.evaluate(&req));
 
         let req = Request::builder()
             .header("foo", "barfuss")
@@ -293,7 +575,7 @@ mod test {
             .uri("http://lala")
             .body("")
             .unwrap();
-        assert!(!rule.check(&req));
+        assert!(!rule.evaluate(&req));
 
         let req = Request::builder()
             .header("fox", "barfuss")
@@ -302,7 +584,7 @@ mod test {
             .uri("https://lala")
             .body("")
             .unwrap();
-        assert!(!rule.check(&req));
+        assert!(!rule.evaluate(&req));
     }
 
     #[test]
@@ -351,7 +633,7 @@ mod test {
             .status(StatusCode::OK)
             .body("")
             .unwrap();
-        assert!(rule.check(&resp));
+        assert!(rule.evaluate(&resp));
 
         let resp = Response::builder()
             .header("foo", "barfuss")
@@ -359,7 +641,7 @@ mod test {
             .status(StatusCode::CONTINUE)
             .body("")
             .unwrap();
-        assert!(rule.check(&resp));
+        assert!(rule.evaluate(&resp));
 
         let resp = Response::builder()
             .header("foo", "barfuss")
@@ -367,7 +649,7 @@ mod test {
             .status(StatusCode::TEMPORARY_REDIRECT)
             .body("")
             .unwrap();
-        assert!(rule.check(&resp));
+        assert!(rule.evaluate(&resp));
 
         let resp = Response::builder()
             .header("foo", "barfuss")
@@ -375,7 +657,7 @@ mod test {
             .status(StatusCode::NOT_FOUND)
             .body("")
             .unwrap();
-        assert!(rule.check(&resp));
+        assert!(rule.evaluate(&resp));
 
         // Test partial matches (no match)
         let resp = Response::builder()
@@ -384,7 +666,7 @@ mod test {
             .status(StatusCode::PERMANENT_REDIRECT)
             .body("")
             .unwrap();
-        assert!(!rule.check(&resp));
+        assert!(!rule.evaluate(&resp));
 
         let resp = Response::builder()
             .header("foo", "barfuss")
@@ -392,6 +674,189 @@ mod test {
             .status(StatusCode::OK)
             .body("")
             .unwrap();
-        assert!(!rule.check(&resp));
+        assert!(!rule.evaluate(&resp));
+    }
+
+    #[test]
+    fn test_request_action() {
+        assert_eq!(
+            RequestAction::from_str("pass").unwrap(),
+            RequestAction::Pass
+        );
+
+        assert_eq!(
+            RequestAction::from_str("block").unwrap(),
+            RequestAction::Block(StatusCode::FORBIDDEN)
+        );
+
+        assert_eq!(
+            RequestAction::from_str("block:451").unwrap(),
+            RequestAction::Block(StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS)
+        );
+
+        assert!(RequestAction::from_str("block:0").is_err());
+        assert!(RequestAction::from_str("block:foo").is_err());
+        assert!(RequestAction::from_str("foo").is_err());
+
+        assert_eq!(
+            RequestAction::from_str("limit:global:10/1m").unwrap(),
+            RequestAction::RateLimit(RateLimitType::Global(
+                Quota::with_period(Duration::from_secs(6))
+                    .unwrap()
+                    .allow_burst(NonZeroU32::new(10).unwrap()),
+                RateLimiter::direct(Quota::with_period(Duration::from_secs(6)).unwrap())
+            ))
+        );
+
+        assert_eq!(
+            RequestAction::from_str("limit:per_ip:10/1m").unwrap(),
+            RequestAction::RateLimit(RateLimitType::PerIp(
+                Quota::with_period(Duration::from_secs(6))
+                    .unwrap()
+                    .allow_burst(NonZeroU32::new(10).unwrap()),
+                RateLimiter::dashmap_with_hasher(
+                    Quota::with_period(Duration::from_secs(6)).unwrap(),
+                    RandomState::new()
+                )
+            ))
+        );
+
+        assert!(RequestAction::from_str("limit").is_err());
+        assert!(RequestAction::from_str("limit:").is_err());
+        assert!(RequestAction::from_str("limit:foo").is_err());
+        assert!(RequestAction::from_str("limit:0/1s").is_err());
+        assert!(RequestAction::from_str("limit:1/0s").is_err());
+        assert!(RequestAction::from_str("limit:1/foo").is_err());
+    }
+
+    #[test]
+    fn test_response_action() {
+        assert_eq!(
+            ResponseAction::from_str("pass").unwrap(),
+            ResponseAction::Pass
+        );
+
+        assert_eq!(
+            ResponseAction::from_str("block").unwrap(),
+            ResponseAction::Block(StatusCode::FORBIDDEN)
+        );
+
+        assert_eq!(
+            ResponseAction::from_str("block:451").unwrap(),
+            ResponseAction::Block(StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS)
+        );
+
+        assert!(ResponseAction::from_str("block:0").is_err());
+        assert!(ResponseAction::from_str("block:foo").is_err());
+        assert!(ResponseAction::from_str("foo").is_err());
+    }
+
+    #[test]
+    fn test_ruleset() {
+        let ruleset = json!({
+            "requests": [{
+                "rule": {
+                    "methods": ["GET", "POST"],
+                    "url": "^https.*",
+                },
+                "action": "limit:global:10/1h",
+            }, {
+                "rule": {
+                    "methods": ["DELETE"],
+                },
+                "action": "block:403",
+            }],
+
+            "responses": [{
+                "rule": {
+                    "status": ["100-200", "400-499", "599"],
+                },
+                "action": "block:451",
+            }, {
+                "rule": {
+                    "status": ["500"],
+                    "headers": [{
+                        "name": "foo",
+                        "value": "bar.*",
+                    }]
+                },
+                "action": "block:401",
+            }]
+        })
+        .to_string();
+
+        let ruleset: Ruleset = serde_json::from_str(&ruleset).unwrap();
+
+        // Test requests
+
+        // Should always pass
+        for _ in 0..1000 {
+            let req = Request::builder().method(Method::OPTIONS).body("").unwrap();
+            assert_eq!(ruleset.evaluate_request(&req), Decision::Pass);
+        }
+
+        // Should always block
+        for _ in 0..1000 {
+            let req = Request::builder().method(Method::DELETE).body("").unwrap();
+            assert_eq!(
+                ruleset.evaluate_request(&req),
+                Decision::Block(StatusCode::FORBIDDEN)
+            );
+        }
+
+        // 10 should go through, the rest throttled
+        for _ in 0..10 {
+            let req = Request::builder()
+                .method(Method::GET)
+                .uri("https://foobar")
+                .body("")
+                .unwrap();
+            assert_eq!(ruleset.evaluate_request(&req), Decision::Pass);
+        }
+
+        for _ in 0..1000 {
+            let req = Request::builder()
+                .method(Method::GET)
+                .uri("https://foobar")
+                .body("")
+                .unwrap();
+            assert!(matches!(
+                ruleset.evaluate_request(&req),
+                Decision::Throttle(_)
+            ));
+        }
+
+        // Test responses
+
+        // Should always pass
+        for _ in 0..1000 {
+            let resp = Response::builder()
+                .status(StatusCode::PERMANENT_REDIRECT)
+                .body("")
+                .unwrap();
+            assert_eq!(ruleset.evaluate_response(&resp), Decision::Pass);
+        }
+
+        // Should always block with 451
+        for _ in 0..1000 {
+            let resp = Response::builder().status(StatusCode::OK).body("").unwrap();
+            assert_eq!(
+                ruleset.evaluate_response(&resp),
+                Decision::Block(StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS)
+            );
+        }
+
+        // Should always block with 401
+        for _ in 0..1000 {
+            let resp = Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .header("foo", "bardead")
+                .body("")
+                .unwrap();
+            assert_eq!(
+                ruleset.evaluate_response(&resp),
+                Decision::Block(StatusCode::UNAUTHORIZED)
+            );
+        }
     }
 }

--- a/src/http/middleware/waf.rs
+++ b/src/http/middleware/waf.rs
@@ -1,0 +1,181 @@
+use std::str::FromStr;
+
+use anyhow::{Context, anyhow};
+use http::{HeaderName, HeaderValue, Method, Request, StatusCode};
+use itertools::Itertools;
+use regex::Regex;
+use serde::Deserialize;
+use serde_with::{DeserializeFromStr, DisplayFromStr, serde_as};
+
+/// Matches HTTP status codes or ranges
+#[derive(Debug, Clone, Copy, Eq, PartialEq, DeserializeFromStr)]
+pub struct StatusRange {
+    from: u16,
+    to: Option<u16>,
+}
+
+impl StatusRange {
+    pub const fn check(&self, v: StatusCode) -> bool {
+        let code = v.as_u16();
+
+        if let Some(to) = self.to {
+            return code >= self.from && code <= to;
+        }
+
+        code == self.from
+    }
+}
+
+impl FromStr for StatusRange {
+    type Err = crate::http::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut it = s.split('-');
+        let (from, to) = (it.next().unwrap(), it.next());
+        let from: u16 = from
+            .trim()
+            .parse()
+            .context("unable to parse status range start")?;
+
+        if !(100..=599).contains(&from) {
+            return Err(anyhow!("Status code can be between 100 and 599, not {from}").into());
+        }
+
+        let to = if let Some(v) = to {
+            let v = v
+                .trim()
+                .parse()
+                .context("unable to parse status range end")?;
+            if !(100..=599).contains(&v) {
+                return Err(anyhow!("Status code can be between 100 and 599, not {v}").into());
+            }
+
+            Some(v)
+        } else {
+            None
+        };
+
+        Ok(Self { from, to })
+    }
+}
+
+/// Matches Header names & values
+#[serde_as]
+#[derive(Deserialize)]
+pub struct HeaderRule {
+    #[serde_as(as = "DisplayFromStr")]
+    pub name: HeaderName,
+    #[serde_as(as = "DisplayFromStr")]
+    pub regex: Regex,
+}
+
+impl HeaderRule {
+    pub fn check(&self, name: &HeaderName, value: &HeaderValue) -> bool {
+        if name != self.name {
+            return false;
+        }
+
+        let Ok(value) = value.to_str() else {
+            return false;
+        };
+
+        self.regex.is_match(value)
+    }
+}
+
+/// Rule to match against HTTP requests
+#[serde_as]
+#[derive(Deserialize)]
+pub struct RequestRule {
+    #[serde_as(as = "Option<Vec<DisplayFromStr>>")]
+    pub methods: Option<Vec<Method>>,
+    pub headers: Option<Vec<HeaderRule>>,
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub url: Option<Regex>,
+}
+
+impl RequestRule {
+    pub fn check<T>(&self, req: &Request<T>) -> bool {
+        // Check if URL matches
+        if let Some(v) = &self.url {
+            if !v.is_match(&req.uri().to_string()) {
+                return false;
+            }
+        }
+
+        // Check if any methods match
+        if let Some(v) = &self.methods {
+            if !v.iter().contains(req.method()) {
+                return false;
+            }
+        }
+
+        // Check that all of header rules match
+        if let Some(v) = &self.headers {
+            if !v.iter().all(|rule| {
+                req.headers()
+                    .iter()
+                    .any(|(name, value)| rule.check(name, value))
+            }) {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+/// Rule to match against HTTP responses
+#[serde_as]
+#[derive(Deserialize)]
+pub struct ResponseRule {
+    pub headers: Option<Vec<HeaderRule>>,
+    pub status: Option<Vec<StatusRange>>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_status_range() {
+        assert_eq!(
+            StatusRange::from_str("100 -   200").unwrap(),
+            StatusRange {
+                from: 100,
+                to: Some(200)
+            }
+        );
+
+        assert_eq!(
+            StatusRange::from_str("100").unwrap(),
+            StatusRange {
+                from: 100,
+                to: None
+            }
+        );
+
+        assert!(StatusRange::from_str("").is_err());
+        assert!(StatusRange::from_str("+").is_err());
+        assert!(StatusRange::from_str("-").is_err());
+        assert!(StatusRange::from_str("99").is_err());
+        assert!(StatusRange::from_str("99-600").is_err());
+        assert!(StatusRange::from_str("99-").is_err());
+        assert!(StatusRange::from_str("-500").is_err());
+        assert!(StatusRange::from_str("101-600").is_err());
+
+        let range = StatusRange::from_str("200-499").unwrap();
+
+        assert!(range.check(StatusCode::OK));
+        assert!(range.check(StatusCode::ACCEPTED));
+        assert!(range.check(StatusCode::PERMANENT_REDIRECT));
+        assert!(range.check(StatusCode::NOT_FOUND));
+        assert!(!range.check(StatusCode::CONTINUE));
+        assert!(!range.check(StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(!range.check(StatusCode::SERVICE_UNAVAILABLE));
+
+        let range = StatusRange::from_str("200").unwrap();
+        assert!(range.check(StatusCode::OK));
+        assert!(!range.check(StatusCode::ACCEPTED));
+    }
+}

--- a/src/http/middleware/waf.rs
+++ b/src/http/middleware/waf.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use anyhow::{Context, anyhow};
-use http::{HeaderName, HeaderValue, Method, Request, StatusCode};
+use http::{HeaderMap, HeaderName, HeaderValue, Method, Request, Response, StatusCode};
 use itertools::Itertools;
 use regex::Regex;
 use serde::Deserialize;
@@ -46,6 +46,7 @@ impl FromStr for StatusRange {
                 .trim()
                 .parse()
                 .context("unable to parse status range end")?;
+
             if !(100..=599).contains(&v) {
                 return Err(anyhow!("Status code can be between 100 and 599, not {v}").into());
             }
@@ -59,17 +60,24 @@ impl FromStr for StatusRange {
     }
 }
 
-/// Matches Header names & values
+/// Matches headers
 #[serde_as]
-#[derive(Deserialize)]
-pub struct HeaderRule {
+#[derive(Debug, Clone, Deserialize)]
+pub struct HeaderMatcher {
     #[serde_as(as = "DisplayFromStr")]
     pub name: HeaderName,
     #[serde_as(as = "DisplayFromStr")]
     pub regex: Regex,
 }
 
-impl HeaderRule {
+impl PartialEq for HeaderMatcher {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.regex.as_str() == other.regex.as_str()
+    }
+}
+impl Eq for HeaderMatcher {}
+
+impl HeaderMatcher {
     pub fn check(&self, name: &HeaderName, value: &HeaderValue) -> bool {
         if name != self.name {
             return false;
@@ -81,20 +89,33 @@ impl HeaderRule {
 
         self.regex.is_match(value)
     }
+
+    pub fn check_headermap(&self, map: &HeaderMap) -> bool {
+        map.iter().any(|(name, value)| self.check(name, value))
+    }
 }
 
-/// Rule to match against HTTP requests
+/// Matches against HTTP requests
 #[serde_as]
-#[derive(Deserialize)]
-pub struct RequestRule {
+#[derive(Debug, Clone, Deserialize)]
+pub struct RequestMatcher {
     #[serde_as(as = "Option<Vec<DisplayFromStr>>")]
     pub methods: Option<Vec<Method>>,
-    pub headers: Option<Vec<HeaderRule>>,
+    pub headers: Option<Vec<HeaderMatcher>>,
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub url: Option<Regex>,
 }
 
-impl RequestRule {
+impl PartialEq for RequestMatcher {
+    fn eq(&self, other: &Self) -> bool {
+        self.methods == other.methods
+            && self.headers == other.headers
+            && self.url.as_ref().map(|x| x.as_str()) == other.url.as_ref().map(|x| x.as_str())
+    }
+}
+impl Eq for RequestMatcher {}
+
+impl RequestMatcher {
     pub fn check<T>(&self, req: &Request<T>) -> bool {
         // Check if URL matches
         if let Some(v) = &self.url {
@@ -112,29 +133,49 @@ impl RequestRule {
 
         // Check that all of header rules match
         if let Some(v) = &self.headers {
-            if !v.iter().all(|rule| {
-                req.headers()
-                    .iter()
-                    .any(|(name, value)| rule.check(name, value))
-            }) {
+            if !v.iter().all(|rule| rule.check_headermap(req.headers())) {
                 return false;
             }
         }
 
+        // Empty rule matches anything
         true
     }
 }
 
-/// Rule to match against HTTP responses
+/// Matches against HTTP responses
 #[serde_as]
-#[derive(Deserialize)]
-pub struct ResponseRule {
-    pub headers: Option<Vec<HeaderRule>>,
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ResponseMatcher {
+    pub headers: Option<Vec<HeaderMatcher>>,
     pub status: Option<Vec<StatusRange>>,
+}
+
+impl ResponseMatcher {
+    pub fn check<T>(&self, req: &Response<T>) -> bool {
+        // Check status codes
+        if let Some(v) = &self.status {
+            if !v.iter().any(|x| x.check(req.status())) {
+                return false;
+            }
+        }
+
+        // Check that all of header rules match
+        if let Some(v) = &self.headers {
+            if !v.iter().all(|rule| rule.check_headermap(req.headers())) {
+                return false;
+            }
+        }
+
+        // Empty rule matches anything
+        true
+    }
 }
 
 #[cfg(test)]
 mod test {
+    use serde_json::json;
+
     use super::*;
 
     #[test]
@@ -177,5 +218,180 @@ mod test {
         let range = StatusRange::from_str("200").unwrap();
         assert!(range.check(StatusCode::OK));
         assert!(!range.check(StatusCode::ACCEPTED));
+    }
+
+    #[test]
+    fn test_request() {
+        let rule = json!({
+            "methods": ["GET", "OPTIONS"],
+            "headers": [
+                {
+                    "name": "foo",
+                    "regex": "^bar.*$"
+                },
+                {
+                    "name": "dead",
+                    "regex": "^beef.*$"
+                }
+            ],
+            "url": "^https",
+        })
+        .to_string();
+
+        let rule: RequestMatcher = serde_json::from_str(&rule).unwrap();
+        assert_eq!(
+            rule,
+            RequestMatcher {
+                methods: Some(vec![Method::GET, Method::OPTIONS]),
+                headers: Some(vec![
+                    HeaderMatcher {
+                        name: HeaderName::from_static("foo"),
+                        regex: Regex::from_str("^bar.*$").unwrap(),
+                    },
+                    HeaderMatcher {
+                        name: HeaderName::from_static("dead"),
+                        regex: Regex::from_str("^beef.*$").unwrap(),
+                    }
+                ]),
+                url: Some(Regex::from_str("^https").unwrap(),)
+            }
+        );
+
+        // Test full matches
+        let req = Request::builder()
+            .header("foo", "barfuss")
+            .header("dead", "beefbeef")
+            .method(Method::GET)
+            .uri("https://lala")
+            .body("")
+            .unwrap();
+        assert!(rule.check(&req));
+
+        let req = Request::builder()
+            .header("foo", "barfuss")
+            .header("dead", "beefbeef")
+            .method(Method::OPTIONS)
+            .uri("https://lala")
+            .body("")
+            .unwrap();
+        assert!(rule.check(&req));
+
+        // Test partial matches (no match)
+        let req = Request::builder()
+            .header("foo", "barfuss")
+            .header("dead", "beefbeef")
+            .method(Method::POST)
+            .uri("https://lala")
+            .body("")
+            .unwrap();
+        assert!(!rule.check(&req));
+
+        let req = Request::builder()
+            .header("foo", "barfuss")
+            .header("dead", "beefbeef")
+            .method(Method::GET)
+            .uri("http://lala")
+            .body("")
+            .unwrap();
+        assert!(!rule.check(&req));
+
+        let req = Request::builder()
+            .header("fox", "barfuss")
+            .header("dead", "beefbeef")
+            .method(Method::GET)
+            .uri("https://lala")
+            .body("")
+            .unwrap();
+        assert!(!rule.check(&req));
+    }
+
+    #[test]
+    fn test_response() {
+        let rule = json!({
+            "status": ["100-200", "307", "400-500"],
+            "headers": [
+                {
+                    "name": "foo",
+                    "regex": "^bar.*$"
+                },
+                {
+                    "name": "dead",
+                    "regex": "^beef.*$"
+                }
+            ],
+        })
+        .to_string();
+
+        let rule: ResponseMatcher = serde_json::from_str(&rule).unwrap();
+        assert_eq!(
+            rule,
+            ResponseMatcher {
+                status: Some(vec![
+                    StatusRange::from_str("100-200").unwrap(),
+                    StatusRange::from_str("307").unwrap(),
+                    StatusRange::from_str("400-500").unwrap()
+                ]),
+                headers: Some(vec![
+                    HeaderMatcher {
+                        name: HeaderName::from_static("foo"),
+                        regex: Regex::from_str("^bar.*$").unwrap(),
+                    },
+                    HeaderMatcher {
+                        name: HeaderName::from_static("dead"),
+                        regex: Regex::from_str("^beef.*$").unwrap(),
+                    }
+                ]),
+            }
+        );
+
+        // Test full matches
+        let resp = Response::builder()
+            .header("foo", "barfuss")
+            .header("dead", "beefbeef")
+            .status(StatusCode::OK)
+            .body("")
+            .unwrap();
+        assert!(rule.check(&resp));
+
+        let resp = Response::builder()
+            .header("foo", "barfuss")
+            .header("dead", "beefbeef")
+            .status(StatusCode::CONTINUE)
+            .body("")
+            .unwrap();
+        assert!(rule.check(&resp));
+
+        let resp = Response::builder()
+            .header("foo", "barfuss")
+            .header("dead", "beefbeef")
+            .status(StatusCode::TEMPORARY_REDIRECT)
+            .body("")
+            .unwrap();
+        assert!(rule.check(&resp));
+
+        let resp = Response::builder()
+            .header("foo", "barfuss")
+            .header("dead", "beefbeef")
+            .status(StatusCode::NOT_FOUND)
+            .body("")
+            .unwrap();
+        assert!(rule.check(&resp));
+
+        // Test partial matches (no match)
+        let resp = Response::builder()
+            .header("foo", "barfuss")
+            .header("dead", "beefbeef")
+            .status(StatusCode::PERMANENT_REDIRECT)
+            .body("")
+            .unwrap();
+        assert!(!rule.check(&resp));
+
+        let resp = Response::builder()
+            .header("foo", "barfuss")
+            .header("dead", "zbeefbeef")
+            .status(StatusCode::OK)
+            .body("")
+            .unwrap();
+        assert!(!rule.check(&resp));
     }
 }

--- a/src/http/middleware/waf.rs
+++ b/src/http/middleware/waf.rs
@@ -776,7 +776,7 @@ pub struct WafCli {
     pub waf_url: Option<Url>,
 
     /// File from which to load WAF rules.
-    /// /// Conflicts with `waf_api` and `waf_url`.
+    /// Conflicts with `waf_api` and `waf_url`.
     #[clap(env, long, group = "waf_input")]
     pub waf_file: Option<PathBuf>,
 

--- a/src/utils/health_manager.rs
+++ b/src/utils/health_manager.rs
@@ -1,5 +1,7 @@
 use std::sync::{Arc, RwLock};
 
+use ic_agent::agent::route_provider::RouteProvider;
+
 use crate::types::Healthy;
 
 /// Aggregates objects that implement Healthy trait.
@@ -18,5 +20,12 @@ impl HealthManager {
 impl Healthy for HealthManager {
     fn healthy(&self) -> bool {
         self.services.read().unwrap().iter().all(|x| x.healthy())
+    }
+}
+
+impl Healthy for Arc<dyn RouteProvider> {
+    fn healthy(&self) -> bool {
+        // We're healthy if there's at least one healthy Boundary Node
+        self.routes_stats().healthy.unwrap_or_default() > 0
     }
 }


### PR DESCRIPTION
Features:
* Processes requests and responses
* Matches:
  - Requests on `Method`, `URL` and `Headers`
  - Responses on `Status` and `Headers`
* Possible actions:
   - For requests: `pass`, `block` with a given status code, `limit` with a configurable ratelimit and a choice of global and per-IP limit
   - For responses: only `pass` and `block`
* Implements `tower::Service` and `tower::Layer` for easy integration into Axum
* Complemented by `WafRunner` that updates the ruleset from the given URL

Also upgrades governor crates to latest versions.

Example ruleset:
```
requests:
  - action: limit:global:100/1m
    rule:
      methods:
        - GET
        - POST
      url: ^https://
      headers:
        - name: foo
          value: ^bar.*

  - action: limit:per_ip:10/1s
    rule:
      methods:
        - OPTIONS

responses:
  - action: block:451
    rule:
      status:
        - 100
        - 200-300
        - 599
      headers:
        - name: foo
          value: ^bar.*
```