### PR TITLE
chore: Update crates, cleanups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,8 +65,8 @@ rustls = { version = "0.23.18", default-features = false, features = [
 ] }
 serde = { version = "1.0.214", features = ["derive"] }
 socket2 = "0.6.0"
-strum = { version = "0.27.1", features = ["derive"] }
-strum_macros = "0.27.1"
+strum = { version = "0.28", features = ["derive"] }
+strum_macros = "0.28"
 thiserror = "2.0.3"
 tokio-util = { version = "0.7.12", features = ["full"] }
 tower-service = "0.3.3"

--- a/ic-bn-lib/Cargo.toml
+++ b/ic-bn-lib/Cargo.toml
@@ -38,7 +38,7 @@ arc-swap = "1.7.1"
 async-channel = "2.3.1"
 async-trait = { workspace = true }
 axum = { workspace = true }
-axum-extra = "0.10.0"
+axum-extra = "0.12.6"
 base64 = "0.22.1"
 bytes = "1.10.0"
 candid = { workspace = true }
@@ -74,13 +74,13 @@ ic-bn-lib-common = "0.1"
 indoc = "2.0.6"
 instant-acme = { workspace = true, optional = true }
 itertools = "0.14.0"
-moka = { version = "=0.12.12", features = ["sync", "future"] }
+moka = { version = "0.12.15", features = ["sync", "future"] }
 nix = { version = "0.30.0", features = ["signal"] }
 ppp = "2.3.0"
 prometheus = { workspace = true }
 prost = { version = "0.14.1", optional = true }
 prost-types = { version = "0.14.1", optional = true }
-rand = { version = "=0.8.5", features = ["small_rng"] }
+rand = { version = "0.8.5", features = ["small_rng"] }
 rcgen = { workspace = true, optional = true }
 regex = "1.11.2"
 reqwest = { workspace = true }
@@ -89,21 +89,24 @@ rustls = { version = "0.23.18", default-features = false, features = [
     "std",
     "brotli",
 ] }
-rustls-acme = { version = "0.14.0", default-features = false, features = [
+rustls-acme = { version = "0.15.1", default-features = false, features = [
     "webpki-roots",
     "tls12",
     "ring",
 ], optional = true }
 rustls-pemfile = "2.2.0"
-rustls-platform-verifier = "0.6.0"
+rustls-platform-verifier = "0.7.0"
 scopeguard = "1.2.0"
 serde = { workspace = true }
 serde_json = "1.0.132"
 serde_with = "3.14.0"
 serde_yaml_ng = "0.10"
-sev = { version = "6.1.0", optional = true }
-sha1 = "0.10.6"
-sha2 = { version = "0.10.9", optional = true }
+sev = { version = "7.1.0", optional = true, default-features = false, features = [
+    "snp",
+    "crypto_nossl",
+] }
+sha1 = "0.11.0"
+sha2 = { version = "0.11.0", optional = true }
 socket2 = "0.6.0"
 strum = { workspace = true }
 strum_macros = { workspace = true }
@@ -127,11 +130,11 @@ url = { workspace = true }
 # DO NOT upgrade, this breaks monorepo compatibility
 # Read https://github.com/uuid-rs/uuid/releases/tag/1.13.0
 uuid = { version = "=1.12.1", features = ["v7"] }
-vrl = { version = "0.26.0", default-features = false, features = [
+vrl = { version = "0.32.0", default-features = false, features = [
     "value",
 ], optional = true }
 webpki-root-certs = "1.0.1"
-x509-parser = "0.17.0"
+x509-parser = "0.18.1"
 zeroize = { version = "1.8.1", features = ["derive"] }
 zstd = "0.13.2"
 

--- a/ic-bn-lib/src/http/mod.rs
+++ b/ic-bn-lib/src/http/mod.rs
@@ -15,11 +15,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use axum::{
-    extract::OriginalUri,
-    response::{IntoResponse, Redirect},
-};
-use axum_extra::extract::Host;
+use axum::response::{IntoResponse, Redirect};
 use http::{HeaderMap, Method, Request, StatusCode, Uri, Version, header::HOST, uri::PathAndQuery};
 use ic_bn_lib_common::types::http::Stats;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
@@ -206,9 +202,12 @@ pub fn url_to_uri(url: &Url) -> Result<Uri, UrlToUriError> {
 
 /// Redirects any request to an HTTPS scheme
 pub async fn redirect_to_https(
-    Host(host): Host,
-    OriginalUri(uri): OriginalUri,
+    request: axum::extract::Request,
 ) -> Result<impl IntoResponse, impl IntoResponse> {
+    let host = extract_authority(&request)
+        .ok_or((StatusCode::BAD_REQUEST, "Unable to extract authority"))?;
+    let uri = request.uri().clone();
+
     let fallback_path = PathAndQuery::from_static("/");
     let pq = uri.path_and_query().unwrap_or(&fallback_path).as_str();
 
@@ -225,7 +224,12 @@ pub async fn redirect_to_https(
 
 #[cfg(test)]
 mod test {
-    use http::{Uri, header::HOST};
+    use axum::{Router, body::Body};
+    use http::{
+        Uri,
+        header::{HOST, LOCATION},
+    };
+    use tower::ServiceExt;
 
     use crate::hval;
 
@@ -339,5 +343,17 @@ mod test {
 
         let url = "unix:/foo/bar".parse().unwrap();
         assert!(url_to_uri(&url).is_err());
+    }
+
+    #[tokio::test]
+    async fn test_redirect_to_https() {
+        let mut request = axum::extract::Request::new(Body::empty());
+        *request.uri_mut() = Uri::from_static("http://foo/bar/baz.bin?a=b");
+
+        let router = Router::new().fallback(redirect_to_https);
+
+        let response = router.oneshot(request).await.unwrap();
+        let location = response.headers().get(LOCATION).unwrap().to_str().unwrap();
+        assert_eq!(location, "https://foo/bar/baz.bin?a=b");
     }
 }

--- a/ic-bn-lib/src/utils/sev_snp.rs
+++ b/ic-bn-lib/src/utils/sev_snp.rs
@@ -7,9 +7,7 @@ use ahash::RandomState;
 use anyhow::Error;
 use axum::{extract::State, response::IntoResponse};
 use bytes::Bytes;
-use clap::Args;
 use http::StatusCode;
-use humantime::parse_duration;
 use moka::sync::{Cache, CacheBuilder};
 use sev::firmware::guest::Firmware;
 


### PR DESCRIPTION
* Update crates
* In a new SEV crate use `crypto_nossl` feature to avoid depending on `openssl` crate (which has some vulns also), also don't use legacy `sev` flag
* Don't use deprecated `Host` extractor from `axum_extras`, add test for redirect to https
* Stop pinning `moka` crate since it's now fixed
* Some cleanups