### PR TITLE
chore: Upgrade `hickory-resolver` crate to 0.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ ic-agent = { version = "0.47", features = [
     "ring",
     "_internal_dynamic-routing",
 ] }
+ic-bn-lib-common = { version = "0.2", path = "./ic-bn-lib-common" }
 instant-acme = { version = "0.8.2", default-features = false, features = [
     "ring",
     "hyper-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,9 @@ cloudflare = { version = "0.14.0", default-features = false, features = [
 ] }
 derive-new = "0.7.0"
 fqdn = { version = "0.5.2" }
-hickory-proto = "0.25.1"
-hickory-resolver = { version = "0.25.1", features = [
+hickory-proto = "0.26.1"
+hickory-resolver = { version = "0.26.1", default-features = false, features = [
+    "tokio",
     "tls-ring",
     "https-ring",
     "dnssec-ring",
@@ -46,9 +47,11 @@ instant-acme = { version = "0.8.2", default-features = false, features = [
     "ring",
     "hyper-rustls",
 ] }
-mail-auth = "0.8.0"
+mail-auth = "0.9.0"
 mail-parser = { version = "0.11.3", features = ["full_encoding"] }
-mail-send = "0.6.0"
+mail-send = { version = "0.6.0", default-features = false, features = [
+    "builder",
+] }
 mockall = "0.13.0"
 parse-size = { version = "1.1.0", features = ["std"] }
 prometheus = "0.14.0"

--- a/ic-bn-lib-common/Cargo.toml
+++ b/ic-bn-lib-common/Cargo.toml
@@ -5,7 +5,7 @@ license.workspace = true
 readme.workspace = true
 keywords.workspace = true
 description = "A collection of traits & types commonly used by ic-bn-lib and others"
-version = "0.1.8"
+version = "0.2.0"
 documentation = "https://docs.rs/ic-bn-lib-common"
 
 [dependencies]

--- a/ic-bn-lib-common/src/traits/dns.rs
+++ b/ic-bn-lib-common/src/traits/dns.rs
@@ -2,7 +2,7 @@ use std::{fmt::Debug, pin::Pin};
 
 use async_trait::async_trait;
 use hickory_proto::rr::{Record, RecordType};
-use hickory_resolver::ResolveError;
+use hickory_resolver::net::NetError;
 use hyper_util::client::legacy::connect::dns::Name;
 use reqwest::dns::Resolve;
 use tower_service::Service;
@@ -12,12 +12,7 @@ use crate::types::{dns::SocketAddrs, http::Error};
 /// Generic trait to resolve a DNS record
 #[async_trait]
 pub trait Resolves: Send + Sync {
-    async fn resolve(
-        &self,
-        record_type: RecordType,
-        name: &str,
-    ) -> Result<Vec<Record>, ResolveError>;
-
+    async fn resolve(&self, record_type: RecordType, name: &str) -> Result<Vec<Record>, NetError>;
     fn flush_cache(&self);
 }
 

--- a/ic-bn-lib-common/src/types/dns.rs
+++ b/ic-bn-lib-common/src/types/dns.rs
@@ -1,12 +1,16 @@
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     str::FromStr,
+    sync::Arc,
     time::Duration,
 };
 
 use anyhow::{Context, anyhow};
 use clap::Args;
-use hickory_resolver::config::{CLOUDFLARE_IPS, LookupIpStrategy};
+use hickory_resolver::config::{
+    ConnectionConfig, LookupIpStrategy, NameServerConfig, ResolveHosts, ResolverConfig,
+    ResolverOpts,
+};
 use humantime::parse_duration;
 use strum::EnumString;
 
@@ -82,26 +86,53 @@ impl FromStr for Protocol {
 /// DNS resolver options
 #[derive(Debug, Clone)]
 pub struct Options {
-    pub protocol: Protocol,
-    pub servers: Vec<IpAddr>,
-    pub lookup_ip_strategy: LookupIpStrategy,
-    pub cache_size: usize,
-    pub timeout: Duration,
-    pub tls_name: String,
-    pub dnssec_disabled: bool,
+    pub opts: ResolverOpts,
+    pub cfg: ResolverConfig,
+}
+
+impl Options {
+    /// Creates simple options with cleartext resolving using the given IPs and port
+    pub fn simple(addrs: &[IpAddr], port: u16) -> Options {
+        let mut opts = ResolverOpts::default();
+        opts.use_hosts_file = ResolveHosts::Never;
+        opts.preserve_intermediates = false;
+        opts.try_tcp_on_error = true;
+
+        let connections = vec![
+            {
+                let mut cfg = ConnectionConfig::udp();
+                cfg.port = port;
+                cfg
+            },
+            {
+                let mut cfg = ConnectionConfig::tcp();
+                cfg.port = port;
+                cfg
+            },
+        ];
+
+        let name_servers = addrs
+            .iter()
+            .map(|x| NameServerConfig::new(*x, true, connections.clone()))
+            .collect();
+        let cfg = ResolverConfig::from_parts(None, vec![], name_servers);
+
+        Self { opts, cfg }
+    }
 }
 
 impl Default for Options {
     fn default() -> Self {
-        Self {
-            protocol: Protocol::Clear(53),
-            servers: CLOUDFLARE_IPS.into(),
-            lookup_ip_strategy: LookupIpStrategy::Ipv4AndIpv6,
-            cache_size: 1024,
-            timeout: Duration::from_secs(3),
-            tls_name: "cloudflare-dns.com".into(),
-            dnssec_disabled: false,
+        // A bit hacky way of using Clap CLI defaults as defaults here
+        use clap::Parser;
+        #[derive(clap::Parser)]
+        struct Cli {
+            #[command(flatten)]
+            dns: DnsCli,
         }
+        let cli = Cli::parse_from([""]);
+
+        Self::from(&cli.dns)
     }
 }
 
@@ -127,12 +158,12 @@ pub struct DnsCli {
 
     /// DNS protocol to use (clear/tls/https) with an optional port separated by a colon.
     /// E.g. "clear:8053". If the port is omitted then the default is used.
-    #[clap(env, long, default_value = "tls")]
+    #[clap(env, long, default_value = "clear")]
     pub dns_protocol: Protocol,
 
     /// Cache size for the resolver (in number of DNS records)
     #[clap(env, long, default_value = "2048")]
-    pub dns_cache_size: usize,
+    pub dns_cache_size: u64,
 
     /// Timeout for resolving
     #[clap(env, long, default_value = "5s", value_parser = parse_duration)]
@@ -155,13 +186,60 @@ pub struct DnsCli {
 impl From<&DnsCli> for Options {
     fn from(c: &DnsCli) -> Self {
         Self {
-            protocol: c.dns_protocol,
-            servers: c.dns_servers.clone(),
-            lookup_ip_strategy: c.dns_lookup_strategy.into(),
-            cache_size: c.dns_cache_size,
-            timeout: c.dns_timeout,
-            tls_name: c.dns_tls_name.clone(),
-            dnssec_disabled: c.dns_dnssec_disabled,
+            opts: ResolverOpts::from(c),
+            cfg: ResolverConfig::from(c),
         }
+    }
+}
+
+impl From<&DnsCli> for ResolverOpts {
+    fn from(c: &DnsCli) -> Self {
+        let mut opts = ResolverOpts::default();
+        opts.cache_size = c.dns_cache_size;
+        opts.timeout = c.dns_timeout;
+        opts.ip_strategy = c.dns_lookup_strategy.into();
+        opts.use_hosts_file = ResolveHosts::Never;
+        opts.preserve_intermediates = false;
+        opts.validate = !c.dns_dnssec_disabled;
+        opts.try_tcp_on_error = true;
+
+        opts
+    }
+}
+
+impl From<&DnsCli> for ResolverConfig {
+    fn from(c: &DnsCli) -> Self {
+        let mut cfg = ResolverConfig::default();
+        for srv in &c.dns_servers {
+            let connections = match c.dns_protocol {
+                Protocol::Clear(port) => vec![
+                    {
+                        let mut cfg = ConnectionConfig::udp();
+                        cfg.port = port;
+                        cfg
+                    },
+                    {
+                        let mut cfg = ConnectionConfig::tcp();
+                        cfg.port = port;
+                        cfg
+                    },
+                ],
+                Protocol::Tls(port) => vec![{
+                    let mut cfg = ConnectionConfig::tls(Arc::from(c.dns_tls_name.as_str()));
+                    cfg.port = port;
+                    cfg
+                }],
+                Protocol::Https(port) => vec![{
+                    let mut cfg = ConnectionConfig::https(Arc::from(c.dns_tls_name.as_str()), None);
+                    cfg.port = port;
+                    cfg
+                }],
+            };
+
+            let name_server = NameServerConfig::new(*srv, true, connections);
+            cfg.add_name_server(name_server);
+        }
+
+        cfg
     }
 }

--- a/ic-bn-lib-common/src/types/http.rs
+++ b/ic-bn-lib-common/src/types/http.rs
@@ -755,21 +755,19 @@ impl<R: CustomBypassReason> CacheBypassReason<R> {
 
 #[cfg(test)]
 mod test {
-    use clap::Parser;
-
     use super::*;
-
-    #[derive(clap::Parser)]
-    struct Cli {
-        #[command(flatten)]
-        server: HttpServerCli,
-        #[command(flatten)]
-        client: HttpClientCli,
-    }
 
     #[test]
     fn test_cli() {
-        let args: Vec<&str> = vec![];
-        Cli::parse_from(args);
+        use clap::Parser;
+        #[derive(clap::Parser)]
+        struct Cli {
+            #[command(flatten)]
+            server: HttpServerCli,
+            #[command(flatten)]
+            client: HttpClientCli,
+        }
+
+        Cli::parse_from([""]);
     }
 }

--- a/ic-bn-lib/Cargo.toml
+++ b/ic-bn-lib/Cargo.toml
@@ -72,7 +72,7 @@ hyper-rustls = { version = "0.27.5", optional = true, default-features = false, 
 ] }
 hyper-util = { workspace = true }
 ic-agent = { workspace = true }
-ic-bn-lib-common = { path = "../ic-bn-lib-common" }
+ic-bn-lib-common = { workspace = true }
 indoc = "2.0.6"
 instant-acme = { workspace = true, optional = true }
 itertools = "0.14.0"

--- a/ic-bn-lib/Cargo.toml
+++ b/ic-bn-lib/Cargo.toml
@@ -72,7 +72,7 @@ hyper-rustls = { version = "0.27.5", optional = true, default-features = false, 
 ] }
 hyper-util = { workspace = true }
 ic-agent = { workspace = true }
-ic-bn-lib-common = "0.1"
+ic-bn-lib-common = { path = "../ic-bn-lib-common" }
 indoc = "2.0.6"
 instant-acme = { workspace = true, optional = true }
 itertools = "0.14.0"

--- a/ic-bn-lib/src/http/dns/mod.rs
+++ b/ic-bn-lib/src/http/dns/mod.rs
@@ -9,9 +9,8 @@ use async_trait::async_trait;
 use candid::Principal;
 use hickory_proto::rr::{Record, RecordType};
 use hickory_resolver::{
-    ResolveError, TokioResolver,
-    config::{NameServerConfigGroup, ResolveHosts, ResolverConfig, ResolverOpts},
-    name_server::TokioConnectionProvider,
+    TokioResolver,
+    net::{NetError, runtime::TokioRuntimeProvider},
 };
 use hyper_util::client::legacy::connect::dns::Name as HyperName;
 use ic_agent::Agent;
@@ -22,13 +21,21 @@ use ic_bn_lib_common::{
         dns::{CloneableDnsResolver, CloneableHyperDnsResolver, HyperDnsResolver, Resolves},
     },
     types::{
-        dns::{Options, Protocol, SocketAddrs},
+        dns::{Options, SocketAddrs},
         http::Error,
     },
 };
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use tokio_util::sync::CancellationToken;
 use tower::Service;
+
+#[derive(thiserror::Error, Debug)]
+pub enum DnsError {
+    #[error("Resolver error: {0}")]
+    Resolver(#[from] NetError),
+    #[error("{0}")]
+    Other(#[from] anyhow::Error),
+}
 
 /// DNS-resolver based on Hickory
 #[derive(Debug, Clone)]
@@ -40,66 +47,45 @@ impl CloneableHyperDnsResolver for Resolver {}
 impl Resolver {
     /// Creates a new resolver with given options.
     /// It must be called in Tokio context.
-    pub fn new(o: Options) -> Self {
-        let name_servers = match o.protocol {
-            Protocol::Clear(p) => NameServerConfigGroup::from_ips_clear(&o.servers, p, true),
-            Protocol::Tls(p) => {
-                NameServerConfigGroup::from_ips_tls(&o.servers, p, o.tls_name, true)
-            }
-            Protocol::Https(p) => {
-                NameServerConfigGroup::from_ips_https(&o.servers, p, o.tls_name, true)
-            }
-        };
+    pub fn new(o: Options) -> Result<Self, NetError> {
+        let resolver = TokioResolver::builder_with_config(o.cfg, TokioRuntimeProvider::default())
+            .with_options(o.opts)
+            .build()?;
 
-        let cfg = ResolverConfig::from_parts(None, vec![], name_servers);
-
-        let mut opts = ResolverOpts::default();
-        opts.cache_size = o.cache_size;
-        opts.timeout = o.timeout;
-        opts.ip_strategy = o.lookup_ip_strategy;
-        opts.use_hosts_file = ResolveHosts::Never;
-        opts.preserve_intermediates = false;
-        opts.validate = !o.dnssec_disabled;
-        opts.try_tcp_on_error = true;
-
-        let builder = TokioResolver::builder_with_config(cfg, TokioConnectionProvider::default())
-            .with_options(opts);
-
-        Self(Arc::new(builder.build()))
+        Ok(Self(Arc::new(resolver)))
     }
 }
 
 impl Default for Resolver {
     fn default() -> Self {
-        Self::new(Options::default())
+        // SAFETY: the defaults shouldn't fail
+        Self::new(Options::default()).unwrap()
     }
 }
 
 // Implement resolving for Reqwest
+// Clippy being stupid here (lifetimes issue).
+#[allow(clippy::needless_collect)]
 impl Resolve for Resolver {
     fn resolve(&self, name: Name) -> Resolving {
         let resolver = self.clone();
 
         Box::pin(async move {
             let lookup = resolver.0.lookup_ip(name.as_str()).await?;
-            let addrs: Addrs = Box::new(SocketAddrs {
-                iter: Box::new(lookup.into_iter()),
-            });
+            let addresses: Vec<IpAddr> = lookup.iter().collect();
 
-            Ok(addrs)
+            Ok(Box::new(SocketAddrs {
+                iter: Box::new(addresses.into_iter()),
+            }) as Addrs)
         })
     }
 }
 
 #[async_trait]
 impl Resolves for Resolver {
-    async fn resolve(
-        &self,
-        record_type: RecordType,
-        name: &str,
-    ) -> Result<Vec<Record>, ResolveError> {
+    async fn resolve(&self, record_type: RecordType, name: &str) -> Result<Vec<Record>, NetError> {
         let lookup = self.0.lookup(name, record_type).await?;
-        Ok(lookup.records().to_vec())
+        Ok(lookup.answers().to_vec())
     }
 
     fn flush_cache(&self) {
@@ -107,7 +93,9 @@ impl Resolves for Resolver {
     }
 }
 
-/// Implement resolving for Hyper
+// Implement resolving for Hyper
+// Clippy being stupid here (lifetimes issue).
+#[allow(clippy::needless_collect)]
 impl Service<HyperName> for Resolver {
     type Response = SocketAddrs;
     type Error = Error;
@@ -122,14 +110,14 @@ impl Service<HyperName> for Resolver {
         let resolver = self.0.clone();
 
         Box::pin(async move {
-            let response = resolver
+            let lookup = resolver
                 .lookup_ip(name.as_str())
                 .await
-                .map_err(|e| Error::DnsError(e.to_string()))?;
-            let addresses = response.into_iter();
+                .map_err(|e: NetError| Error::DnsError(e.to_string()))?;
+            let addresses: Vec<IpAddr> = lookup.iter().collect();
 
             Ok(SocketAddrs {
-                iter: Box::new(addresses),
+                iter: Box::new(addresses.into_iter()),
             })
         })
     }
@@ -144,8 +132,8 @@ impl HyperDnsResolver for FixedResolver {}
 impl CloneableHyperDnsResolver for FixedResolver {}
 
 impl FixedResolver {
-    pub fn new(o: Options, name: String) -> Result<Self, Error> {
-        let resolver = Resolver::new(o);
+    pub fn new(o: Options, name: String) -> Result<Self, DnsError> {
+        let resolver = Resolver::new(o)?;
         let hyper_name = HyperName::from_str(&name).context("unable to parse name")?;
 
         Ok(Self(resolver, name, hyper_name))
@@ -301,7 +289,7 @@ impl Resolve for ApiBnResolver {
                         .lookup_ip(name.as_str())
                         .await
                         .map_err(|e| Error::DnsError(e.to_string()))?
-                        .into_iter()
+                        .iter()
                         .collect()
                 }
             };
@@ -338,7 +326,7 @@ impl Service<HyperName> for ApiBnResolver {
                         .lookup_ip(name.as_str())
                         .await
                         .map_err(|e| Error::DnsError(e.to_string()))?
-                        .into_iter()
+                        .iter()
                         .collect()
                 }
             };
@@ -388,6 +376,8 @@ impl Resolve for SingleResolver {
 #[cfg(test)]
 mod test {
     use std::net::{Ipv4Addr, SocketAddr};
+
+    use ic_bn_lib_common::types::dns::Protocol;
 
     use super::*;
 

--- a/ic-bn-lib/src/smtp/inbound/ehlo.rs
+++ b/ic-bn-lib/src/smtp/inbound/ehlo.rs
@@ -1,7 +1,6 @@
 use std::str::FromStr;
 
 use fqdn::FQDN;
-use mail_auth::hickory_resolver::proto::ProtoErrorKind;
 
 use crate::{
     network::AsyncReadWrite,
@@ -42,7 +41,7 @@ impl<S: AsyncReadWrite> Session<S> {
                 }
 
                 Err(e) => {
-                    if matches!(e.kind(), ProtoErrorKind::NoRecordsFound(_)) {
+                    if e.is_no_records_found() {
                         return self
                             .reply("550", "5.5.0", "EHLO hostname not found in DNS.")
                             .await;

--- a/ic-bn-lib/src/tests/pebble.rs
+++ b/ic-bn-lib/src/tests/pebble.rs
@@ -10,10 +10,7 @@ use std::{
 
 use anyhow::{Context, Error, anyhow};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use ic_bn_lib_common::{
-    traits::dns::Resolves,
-    types::dns::{Options, Protocol},
-};
+use ic_bn_lib_common::{traits::dns::Resolves, types::dns::Options};
 use nix::{
     sys::signal::{Signal, kill},
     unistd::Pid,
@@ -381,11 +378,8 @@ impl Env {
 
     /// Returns a ready-to-use DNS resolver targeting pebble-challtestsrv
     pub fn resolver(&self) -> Arc<dyn Resolves> {
-        let mut opts = Options::default();
-        opts.protocol = Protocol::Clear(self.port_dns_cleartext());
-        opts.servers = vec![self.ip_dns_cleartext()];
-
-        Arc::new(Resolver::new(opts))
+        let opts = Options::simple(&[self.ip_dns_cleartext()], self.port_dns_cleartext());
+        Arc::new(Resolver::new(opts).unwrap())
     }
 
     /// Stops the environment
@@ -532,7 +526,7 @@ pub mod dns {
                 .await
                 .unwrap();
             assert_eq!(r[0].record_type(), RecordType::TXT);
-            assert_eq!(r[0].data().to_string(), "bar");
+            assert_eq!(r[0].data.to_string(), "bar");
 
             tm.unset("foo").await.unwrap();
             let r = resolver
@@ -550,7 +544,7 @@ pub mod dns {
                     .await
                     .unwrap();
                 assert_eq!(r[0].record_type(), RecordType::TXT);
-                assert_eq!(r[0].data().to_string(), "deadbeef");
+                assert_eq!(r[0].data.to_string(), "deadbeef");
 
                 tm.unset("baz").await.unwrap();
                 let r = resolver

--- a/ic-bn-lib/src/tls/acme/dns/mod.rs
+++ b/ic-bn-lib/src/tls/acme/dns/mod.rs
@@ -96,7 +96,7 @@ impl TokenManager for TokenManagerDns {
             // See if any of them matches given token
             records
                 .iter()
-                .find(|&x| x.record_type() == RecordType::TXT && x.data().to_string() == token)
+                .find(|&x| x.record_type() == RecordType::TXT && x.data.to_string() == token)
                 .ok_or_else(|| RetryError::Transient(anyhow!("requested record not found")))?;
 
             Ok(())


### PR DESCRIPTION
To align with the crate version used in `mail-auth` SMTP-related crate, hickory had quite a lot API changes since 0.25.