### PR TITLE
feat(NODE-1955): SMTP, DNS fixes & more logging

### DIFF
--- a/ic-bn-lib-common/Cargo.toml
+++ b/ic-bn-lib-common/Cargo.toml
@@ -5,7 +5,7 @@ license.workspace = true
 readme.workspace = true
 keywords.workspace = true
 description = "A collection of traits & types commonly used by ic-bn-lib and others"
-version = "0.2.0"
+version = "0.2.1"
 documentation = "https://docs.rs/ic-bn-lib-common"
 
 [dependencies]

--- a/ic-bn-lib-common/src/types/dns.rs
+++ b/ic-bn-lib-common/src/types/dns.rs
@@ -27,7 +27,7 @@ pub const DEFAULT_RESOLVERS: &[IpAddr] = &[
 ];
 
 /// Copycat of `hickory_resolver::config::LookupIpStrategy` but with `FromStr` derived for CLI
-#[derive(Clone, Copy, Debug, PartialEq, Eq, EnumString)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, EnumString)]
 #[strum(serialize_all = "snake_case")]
 pub enum LookupStrategy {
     /// Only query for A (Ipv4) records
@@ -35,10 +35,11 @@ pub enum LookupStrategy {
     /// Only query for AAAA (Ipv6) records
     Ipv6Only,
     /// Query for A and AAAA in parallel
+    #[default]
     Ipv4AndIpv6,
     /// Query for Ipv6 if that fails, query for Ipv4
     Ipv6ThenIpv4,
-    /// Query for Ipv4 if that fails, query for Ipv6 (default)
+    /// Query for Ipv4 if that fails, query for Ipv6
     Ipv4ThenIpv6,
 }
 
@@ -169,6 +170,10 @@ pub struct DnsCli {
     #[clap(env, long, default_value = "5s", value_parser = parse_duration)]
     pub dns_timeout: Duration,
 
+    /// Number of resolving attempts to do
+    #[clap(env, long, default_value = "3")]
+    pub dns_attempts: usize,
+
     /// TLS name to expect for TLS and HTTPS protocols (e.g. "dns.google" or "cloudflare-dns.com")
     #[clap(env, long, default_value = "cloudflare-dns.com")]
     pub dns_tls_name: String,
@@ -197,6 +202,7 @@ impl From<&DnsCli> for ResolverOpts {
         let mut opts = ResolverOpts::default();
         opts.cache_size = c.dns_cache_size;
         opts.timeout = c.dns_timeout;
+        opts.attempts = c.dns_attempts;
         opts.ip_strategy = c.dns_lookup_strategy.into();
         opts.use_hosts_file = ResolveHosts::Never;
         opts.preserve_intermediates = false;

--- a/ic-bn-lib/src/lib.rs
+++ b/ic-bn-lib/src/lib.rs
@@ -181,3 +181,26 @@ macro_rules! dyn_event {
         }
     };
 }
+
+/// Truncates the given string to around n *bytes*,
+/// on the closest UTF-8 grapheme boundary.
+pub fn truncate(s: &str, n: usize) -> &str {
+    let n = s.len().min(n);
+    let m = (0..=n)
+        .rfind(|m| s.is_char_boundary(*m))
+        .unwrap_or_default();
+    &s[..m]
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_trucate() {
+        assert_eq!(truncate("foobarbaz", 4), "foob");
+        assert_eq!(truncate("tättähäärä härkä", 12), "tättähää");
+        assert_eq!(truncate("", 99), "");
+        assert_eq!(truncate("foobarbaz", 99), "foobarbaz");
+    }
+}

--- a/ic-bn-lib/src/lib.rs
+++ b/ic-bn-lib/src/lib.rs
@@ -183,7 +183,7 @@ macro_rules! dyn_event {
 }
 
 /// Truncates the given string to around n *bytes*,
-/// on the closest UTF-8 grapheme boundary.
+/// on the closest UTF-8 code point boundary.
 pub fn truncate(s: &str, n: usize) -> &str {
     let n = s.len().min(n);
     let m = (0..=n)
@@ -197,10 +197,11 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_trucate() {
+    fn test_truncate() {
         assert_eq!(truncate("foobarbaz", 4), "foob");
         assert_eq!(truncate("tättähäärä härkä", 12), "tättähää");
         assert_eq!(truncate("", 99), "");
+        assert_eq!(truncate("🏁", 2), "");
         assert_eq!(truncate("foobarbaz", 99), "foobarbaz");
     }
 }

--- a/ic-bn-lib/src/smtp/cli.rs
+++ b/ic-bn-lib/src/smtp/cli.rs
@@ -72,17 +72,23 @@ pub struct SmtpServerCli {
     #[clap(env, long)]
     pub smtp_server_tls_required: bool,
 
-    /// Whether to verify client's EHLO hostname (A record)
+    /// Whether to verify client's EHLO hostname.
+    /// Checks that it's an FQDN & that an A/AAAA record exists.
     #[clap(env, long)]
     pub smtp_server_verify_ehlo_hostname: bool,
 
-    /// Whether to verify reverse IP of the SMTP clients.
-    /// It should resolve to a hostname and that hostname should resolve back to the same IP.
-    /// Also an IP should match the client's IP.
+    /// Whether to verify reverse IP of SMTP clients.
+    /// The IP needs to have a PTR record present.
     #[clap(env, long)]
     pub smtp_server_verify_reverse_ip: bool,
 
-    /// Whether to verify the sender's domain (check FQDN and lookup MX records)
+    /// Whether to apply stricter rules to the reverse IP of SMTP clients.
+    /// The PTR record should resolve back to the client's IP.
+    /// This also maps permanent validation errors to the permanent SMTP failures (5xx).
+    #[clap(env, long)]
+    pub smtp_server_verify_reverse_ip_strict: bool,
+
+    /// Whether to verify the sender's domain (check it's an FQDN and look up MX records)
     #[clap(env, long)]
     pub smtp_server_verify_sender_domain: bool,
 
@@ -122,6 +128,7 @@ impl TryFrom<&SmtpServerCli> for SessionConfig {
 
         cfg.verify_ehlo_hostname = v.smtp_server_verify_ehlo_hostname;
         cfg.verify_reverse_ip = v.smtp_server_verify_reverse_ip;
+        cfg.verify_reverse_ip_strict = v.smtp_server_verify_reverse_ip_strict;
         cfg.verify_sender_domain = v.smtp_server_verify_sender_domain;
         cfg.verify_spf = v.smtp_server_verify_spf;
         cfg.verify_dkim = v.smtp_server_verify_dkim;

--- a/ic-bn-lib/src/smtp/ic/delivery_agent.rs
+++ b/ic-bn-lib/src/smtp/ic/delivery_agent.rs
@@ -322,11 +322,16 @@ impl ResolvesRecipient for IcSmtpDeliveryAgent {
             .canister_request(canister_id, ic_smtp_request, true)
             .await
             .map_err(|e| match e {
-                IcSmtpDeliveryAgentError::Agent(AgentError::InvalidMethodError(_)) => {
+                IcSmtpDeliveryAgentError::Agent(
+                    AgentError::CertifiedReject { reject, .. }
+                    | AgentError::UncertifiedReject { reject, .. },
+                    // It seems it's the only way to check that canister is missing a method
+                ) if reject.error_code.as_ref().is_some_and(|x| x == "IC0536") => {
                     RecipientResolveError::Permanent(format!(
                         "Canister {canister_id} does not support SMTP protocol"
                     ))
                 }
+
                 _ => RecipientResolveError::Temporary(e.to_string()),
             })?;
 

--- a/ic-bn-lib/src/smtp/ic/mod.rs
+++ b/ic-bn-lib/src/smtp/ic/mod.rs
@@ -92,19 +92,14 @@ pub fn parse_email(raw: &[u8]) -> Result<Message, IcSmtpDeliveryAgentError> {
     // Get the offset to the beginning of the body
     let body_offset = parsed.root_part().offset_body as usize;
 
-    // Should never happen, just a precaution
-    if body_offset >= raw.len() {
-        return Err(IcSmtpDeliveryAgentError::Parser(
-            "Incorrect body offset".into(),
-        ));
-    }
-
-    let msg = Message {
-        headers,
-        body: raw[body_offset..].into(),
+    // In case of an empty body the offeset would be == len
+    let body = if body_offset >= raw.len() {
+        vec![]
+    } else {
+        raw[body_offset..].into()
     };
 
-    Ok(msg)
+    Ok(Message { headers, body })
 }
 
 #[cfg(test)]
@@ -224,5 +219,23 @@ mod tests {
             parse_email(raw.as_bytes()).unwrap_err(),
             IcSmtpDeliveryAgentError::Parser(_)
         ));
+    }
+
+    #[test]
+    fn test_empty_body() {
+        let raw = indoc! {r#"
+            From: Igor Novgorodov <igor@novg.net>
+            Content-Type: text/plain
+            Content-Transfer-Encoding: 7bit
+            Mime-Version: 1.0 (Mac OS X Mail 16.0 \(3864.600.51.1.1\))
+            Subject: II-Recovery-ae3eb3c2fff5b256
+            X-Universally-Unique-Identifier: 1096E119-BB3F-4C1C-B43F-CE5FD830D693
+            Message-Id: <A05648D4-1996-4B72-8D18-FC5122445F27@novg.net>
+            Date: Wed, 27 May 2026 12:10:22 +0200
+            To: register@beta.id.ai
+
+        "#};
+
+        parse_email(raw.as_bytes()).unwrap();
     }
 }

--- a/ic-bn-lib/src/smtp/ic/mod.rs
+++ b/ic-bn-lib/src/smtp/ic/mod.rs
@@ -92,7 +92,7 @@ pub fn parse_email(raw: &[u8]) -> Result<Message, IcSmtpDeliveryAgentError> {
     // Get the offset to the beginning of the body
     let body_offset = parsed.root_part().offset_body as usize;
 
-    // In case of an empty body the offeset would be == len
+    // In case of an empty body the offset would be == len
     let body = if body_offset >= raw.len() {
         vec![]
     } else {
@@ -236,6 +236,7 @@ mod tests {
 
         "#};
 
-        parse_email(raw.as_bytes()).unwrap();
+        let r = parse_email(raw.as_bytes()).unwrap();
+        assert!(r.body.is_empty());
     }
 }

--- a/ic-bn-lib/src/smtp/ic/mod.rs
+++ b/ic-bn-lib/src/smtp/ic/mod.rs
@@ -93,8 +93,13 @@ pub fn parse_email(raw: &[u8]) -> Result<Message, IcSmtpDeliveryAgentError> {
     let body_offset = parsed.root_part().offset_body as usize;
 
     // In case of an empty body the offset would be == len
-    let body = if body_offset >= raw.len() {
+    let body = if body_offset == raw.len() {
         vec![]
+    } else if body_offset > raw.len() {
+        // Should never happen, unless the parser is broken
+        return Err(IcSmtpDeliveryAgentError::Parser(
+            "Body offset incorrect".into(),
+        ));
     } else {
         raw[body_offset..].into()
     };

--- a/ic-bn-lib/src/smtp/inbound/ehlo.rs
+++ b/ic-bn-lib/src/smtp/inbound/ehlo.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use fqdn::FQDN;
+use tracing::{debug, info};
 
 use crate::{
     http::dns::is_error_negative_lookup,
@@ -13,6 +14,7 @@ impl<S: AsyncReadWrite> Session<S> {
     pub async fn handle_ehlo(&mut self, host: &str, extended: bool) -> SessionResult<()> {
         // Validate hostname
         let Ok(ehlo_hostname) = FQDN::from_str(host) else {
+            info!("{self}: {host}: Invalid EHLO hostname");
             return self.reply("550", "5.5.0", "Invalid EHLO hostname.").await;
         };
 
@@ -25,6 +27,7 @@ impl<S: AsyncReadWrite> Session<S> {
         }
 
         if ehlo_hostname.depth() < 2 {
+            info!("{self}: {host}: EHLO is not FQDN");
             return self
                 .reply("550", "5.5.0", "EHLO hostname must be an FQDN.")
                 .await;
@@ -33,15 +36,21 @@ impl<S: AsyncReadWrite> Session<S> {
         // Check if EHLO hostname resolves if configured
         if self.cfg.verify_ehlo_hostname {
             match self.cfg.authenticator.resolver().lookup_ip(host).await {
-                Ok(v) => {
-                    if v.iter().next().is_none() {
+                Ok(v) => match v.iter().next() {
+                    Some(v) => {
+                        debug!("{self}: {host}: EHLO hostname found in DNS: {v}");
+                    }
+                    None => {
+                        info!("{self}: {host}: EHLO not found in DNS");
                         return self
                             .reply("550", "5.5.0", "EHLO hostname not found in DNS.")
                             .await;
                     }
-                }
+                },
 
                 Err(e) => {
+                    info!("{self}: {host}: EHLO not found in DNS: {e:#}");
+
                     if is_error_negative_lookup(&e) {
                         return self
                             .reply("550", "5.5.0", "EHLO hostname not found in DNS.")

--- a/ic-bn-lib/src/smtp/inbound/mail_from.rs
+++ b/ic-bn-lib/src/smtp/inbound/mail_from.rs
@@ -1,7 +1,9 @@
-use std::{borrow::Cow, fmt::Write as _, str::FromStr};
+use std::{borrow::Cow, fmt::Write as _, net::IpAddr, str::FromStr};
 
-use mail_auth::{IprevResult, Parameters, SpfResult, spf::verify::SpfParameters};
+use hickory_proto::rr::RData;
+use mail_auth::{SpfResult, spf::verify::SpfParameters};
 use smtp_proto::{MAIL_BY_NOTIFY, MAIL_BY_RETURN, MailFrom};
+use tracing::{debug, info};
 
 use crate::{
     http::dns::is_error_negative_lookup,
@@ -15,7 +17,7 @@ use crate::{
 impl<S: AsyncReadWrite> Session<S> {
     /// Handles MAIL FROM command
     pub async fn handle_mail_from(&mut self, from: MailFrom<Cow<'_, str>>) -> SessionResult<()> {
-        let Some(helo_hostname) = &self.data.ehlo_hostname else {
+        let Some(helo_hostname) = self.data.ehlo_hostname.as_ref().map(|x| x.to_string()) else {
             return self
                 .reply("503", "5.5.1", "Polite people say EHLO first.")
                 .await;
@@ -63,33 +65,25 @@ impl<S: AsyncReadWrite> Session<S> {
 
         // Validate address
         let Ok(address) = EmailAddress::from_str(&from.address) else {
+            info!("{self}: {}: incorrect sender address", from.address);
             return self
                 .reply("550", "5.7.1", "Sender address is incorrect.")
                 .await;
         };
 
-        // Validate reverse IP if configured
-        if self.cfg.verify_reverse_ip {
-            let result = self
-                .cfg
-                .authenticator
-                .verify_iprev(Parameters::from(self.remote_ip))
-                .await
-                .result;
-
-            if !matches!(result, IprevResult::Pass) {
-                let (code, ext, msg) = if matches!(result, IprevResult::TempError(_)) {
-                    ("451", "4.7.25", "Temporary error validating reverse DNS.")
-                } else {
-                    ("550", "5.7.25", "Reverse DNS validation failed.")
-                };
-
-                return self.reply(code, ext, msg).await;
+        // Validate reverse IP if configured & not yet verified
+        if self.cfg.verify_reverse_ip && !self.data.reverse_ip_verified {
+            if !self.verify_reverse_ip().await? {
+                return Ok(());
             }
+
+            self.data.reverse_ip_verified = true;
+            debug!("{self}: reverse IP verification succeeded");
         }
 
         if self.cfg.verify_sender_domain {
             if address.domain().depth() < 2 {
+                info!("{self}: {address}: sender domain verification failed: not FQDN");
                 return self.reply("550", "5.7.2", "Sender must be an FQDN.").await;
             };
 
@@ -102,6 +96,9 @@ impl<S: AsyncReadWrite> Session<S> {
             {
                 Ok(v) => {
                     if v.answers().is_empty() {
+                        info!(
+                            "{self}: {address}: sender domain verification failed: no MX records found"
+                        );
                         return self
                             .reply(
                                 "550",
@@ -113,6 +110,9 @@ impl<S: AsyncReadWrite> Session<S> {
                 }
                 Err(e) => {
                     if is_error_negative_lookup(&e) {
+                        info!(
+                            "{self}: {address}: sender domain verification failed: no MX records found"
+                        );
                         return self
                             .reply(
                                 "550",
@@ -121,12 +121,17 @@ impl<S: AsyncReadWrite> Session<S> {
                             )
                             .await;
                     } else {
+                        info!(
+                            "{self}: {address}: sender domain verification failed: temporary error: {e:#}"
+                        );
                         return self
                             .reply("451", "4.7.25", "Temporary error validating sender domain.")
                             .await;
                     }
                 }
             }
+
+            debug!("{self}: sender domain verification succeeded");
         }
 
         if self.cfg.verify_spf {
@@ -135,7 +140,7 @@ impl<S: AsyncReadWrite> Session<S> {
                 .authenticator
                 .verify_spf(SpfParameters::verify_mail_from(
                     self.remote_ip,
-                    &helo_hostname.to_string(),
+                    &helo_hostname,
                     &self.cfg.hostname,
                     &from.address,
                 ))
@@ -144,11 +149,21 @@ impl<S: AsyncReadWrite> Session<S> {
             match output.result() {
                 SpfResult::Pass | SpfResult::Neutral | SpfResult::None => {}
                 SpfResult::TempError => {
+                    info!(
+                        "{self}: {address}: SPF verification failed: temporary error: {:?}",
+                        output.explanation()
+                    );
+
                     return self
                         .reply("451", "4.7.24", "Temporary SPF validation error.")
                         .await;
                 }
                 SpfResult::Fail | SpfResult::PermError | SpfResult::SoftFail => {
+                    info!(
+                        "{self}: {address}: SPF verification failed: permanent error: {:?}",
+                        output.explanation()
+                    );
+
                     return self
                         .reply_with("550", "5.7.23", |buf| {
                             write!(buf, "SPF validation failed")?;
@@ -160,11 +175,144 @@ impl<S: AsyncReadWrite> Session<S> {
                         .await;
                 }
             }
+
+            debug!("{self}: {address}: SPF verification succeeded");
         }
 
         self.reply("250", "2.1.0", "OK").await?;
         self.data.mail_from = Some(address);
 
         Ok(())
+    }
+
+    async fn verify_reverse_ip_reply(&mut self, permanent: bool, msg: &str) -> SessionResult<bool> {
+        // Emit permanent errors only if in strict mode
+        if permanent && self.cfg.verify_reverse_ip_strict {
+            self.reply_with("550", "5.7.25", |buf| {
+                write!(buf, "Reverse DNS validation failed: {msg}")
+            })
+            .await?;
+        } else {
+            self.reply_with("451", "4.7.25", |buf| {
+                write!(buf, "Temporary error validating reverse DNS: {msg}")
+            })
+            .await?;
+        }
+
+        Ok(false)
+    }
+
+    async fn verify_reverse_ip(&mut self) -> SessionResult<bool> {
+        let remote_ip = self.remote_ip;
+
+        // Get PTR records
+        let lookup = match self
+            .cfg
+            .authenticator
+            .resolver()
+            .reverse_lookup(remote_ip)
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                info!("{self}: reverse IP verification failed: PTR lookup failed: {e:#}");
+                return self
+                    .verify_reverse_ip_reply(
+                        is_error_negative_lookup(&e),
+                        "unable to look up PTR record",
+                    )
+                    .await;
+            }
+        };
+
+        if lookup.answers().is_empty() {
+            info!("{self}: reverse IP verification failed: no PTR records");
+            return self
+                .verify_reverse_ip_reply(true, "no PTR records found")
+                .await;
+        }
+
+        // In non-strict mode we're already happy
+        if !self.cfg.verify_reverse_ip_strict {
+            return Ok(true);
+        }
+
+        // Take max 3 PTRs from the response to avoid DoS.
+        // Usually there should be only one anyway.
+        for ptr in lookup.answers().iter().take(3).filter_map(|r| {
+            let RData::PTR(ptr) = &r.data else {
+                return None;
+            };
+
+            Some(ptr.to_lowercase())
+        }) {
+            match remote_ip {
+                IpAddr::V4(remote_ip_v4) => {
+                    let lookup = match self.cfg.authenticator.resolver().ipv4_lookup(ptr).await {
+                        Ok(v) => v,
+                        Err(e) => {
+                            info!("{self}: reverse IP verification: PTR->IP lookup failed: {e:#}");
+                            return self
+                                .verify_reverse_ip_reply(
+                                    is_error_negative_lookup(&e),
+                                    "unable to look up IP for the PTR record",
+                                )
+                                .await;
+                        }
+                    };
+
+                    // Check if any of the addresses match the client's
+                    for v in lookup.answers().iter().filter_map(|r| {
+                        if let RData::A(a) = &r.data {
+                            Some(a.0)
+                        } else {
+                            None
+                        }
+                    }) {
+                        if v == remote_ip_v4 {
+                            return Ok(true);
+                        }
+                    }
+                }
+
+                IpAddr::V6(remote_ip_v6) => {
+                    let lookup = match self.cfg.authenticator.resolver().ipv6_lookup(ptr).await {
+                        Ok(v) => v,
+                        Err(e) => {
+                            info!("{self}: reverse IP verification: PTR->IP lookup failed: {e:#}");
+                            return self
+                                .verify_reverse_ip_reply(
+                                    is_error_negative_lookup(&e),
+                                    "unable to look up IP for the PTR record",
+                                )
+                                .await;
+                        }
+                    };
+
+                    // Check if any of the addresses match the client's
+                    for v in lookup.answers().iter().filter_map(|r| {
+                        if let RData::AAAA(a) = &r.data {
+                            Some(a.0)
+                        } else {
+                            None
+                        }
+                    }) {
+                        if v == remote_ip_v6 {
+                            return Ok(true);
+                        }
+                    }
+                }
+            };
+        }
+
+        info!(
+            "{self}: reverse IP verification failed: no addresses matching client's IP found after resolving PTR"
+        );
+        return self
+            .verify_reverse_ip_reply(
+                true,
+                "no addresses matching client's IP found after resolving PTR",
+            )
+            .await;
     }
 }

--- a/ic-bn-lib/src/smtp/inbound/mail_from.rs
+++ b/ic-bn-lib/src/smtp/inbound/mail_from.rs
@@ -4,6 +4,7 @@ use hickory_proto::rr::{
     Name, RData,
     rdata::{A, AAAA},
 };
+use hickory_resolver::net::NetError;
 use mail_auth::{SpfResult, spf::verify::SpfParameters};
 use smtp_proto::{MAIL_BY_NOTIFY, MAIL_BY_RETURN, MailFrom};
 use tracing::{debug, info};
@@ -207,53 +208,27 @@ impl<S: AsyncReadWrite> Session<S> {
     }
 
     /// Checks if given PTR resolves back to the client's IP
-    async fn verify_reverse_ip_ptr(&mut self, ptr: Name) -> SessionResult<bool> {
+    async fn verify_reverse_ip_ptr(&self, ptr: Name) -> Result<bool, NetError> {
         let remote_ip = self.remote_ip;
 
         match remote_ip {
-            IpAddr::V4(remote_ip_v4) => {
-                let lookup = match self.cfg.authenticator.resolver().ipv4_lookup(ptr).await {
-                    Ok(v) => v,
-                    Err(e) => {
-                        info!("{self}: reverse IP verification: PTR->IP lookup failed: {e:#}");
-                        return self
-                            .verify_reverse_ip_reply(
-                                is_error_negative_lookup(&e),
-                                "unable to look up IP for the PTR record",
-                            )
-                            .await;
-                    }
-                };
+            IpAddr::V4(v4) => {
+                let lookup = self.cfg.authenticator.resolver().ipv4_lookup(ptr).await?;
 
                 // Check if any of the addresses match the client's
-                if lookup
-                    .answers()
-                    .iter()
-                    .any(|x| x.data == RData::A(A(remote_ip_v4)))
-                {
+                if lookup.answers().iter().any(|x| x.data == RData::A(A(v4))) {
                     return Ok(true);
                 }
             }
 
-            IpAddr::V6(remote_ip_v6) => {
-                let lookup = match self.cfg.authenticator.resolver().ipv6_lookup(ptr).await {
-                    Ok(v) => v,
-                    Err(e) => {
-                        info!("{self}: reverse IP verification: PTR->IP lookup failed: {e:#}");
-                        return self
-                            .verify_reverse_ip_reply(
-                                is_error_negative_lookup(&e),
-                                "unable to look up IP for the PTR record",
-                            )
-                            .await;
-                    }
-                };
+            IpAddr::V6(v6) => {
+                let lookup = self.cfg.authenticator.resolver().ipv6_lookup(ptr).await?;
 
                 // Check if any of the addresses match the client's
                 if lookup
                     .answers()
                     .iter()
-                    .any(|x| x.data == RData::AAAA(AAAA(remote_ip_v6)))
+                    .any(|x| x.data == RData::AAAA(AAAA(v6)))
                 {
                     return Ok(true);
                 }
@@ -301,6 +276,7 @@ impl<S: AsyncReadWrite> Session<S> {
 
         // Take max 3 PTRs from the response to avoid DoS.
         // Usually there should be only one anyway.
+        let mut last_error = None;
         for ptr in lookup
             .answers()
             .iter()
@@ -310,11 +286,30 @@ impl<S: AsyncReadWrite> Session<S> {
             })
             .take(3)
         {
-            if self.verify_reverse_ip_ptr(ptr).await? {
-                return Ok(true);
+            match self.verify_reverse_ip_ptr(ptr).await {
+                Ok(v) => {
+                    if v {
+                        return Ok(true);
+                    }
+                }
+                Err(e) => {
+                    info!("{self}: reverse IP verification: PTR->IP lookup failed: {e:#}");
+                    last_error = Some(e);
+                }
             }
         }
 
+        // Return the last error if there was any
+        if let Some(e) = last_error {
+            return self
+                .verify_reverse_ip_reply(
+                    is_error_negative_lookup(&e),
+                    "unable to look up IP for the PTR record",
+                )
+                .await;
+        }
+
+        // Otherwise everything succeeded but no matches found
         info!(
             "{self}: reverse IP verification failed: no addresses matching client's IP found after resolving PTR"
         );

--- a/ic-bn-lib/src/smtp/inbound/mail_from.rs
+++ b/ic-bn-lib/src/smtp/inbound/mail_from.rs
@@ -1,6 +1,9 @@
 use std::{borrow::Cow, fmt::Write as _, net::IpAddr, str::FromStr};
 
-use hickory_proto::rr::RData;
+use hickory_proto::rr::{
+    Name, RData,
+    rdata::{A, AAAA},
+};
 use mail_auth::{SpfResult, spf::verify::SpfParameters};
 use smtp_proto::{MAIL_BY_NOTIFY, MAIL_BY_RETURN, MailFrom};
 use tracing::{debug, info};
@@ -150,7 +153,7 @@ impl<S: AsyncReadWrite> Session<S> {
                 SpfResult::Pass | SpfResult::Neutral | SpfResult::None => {}
                 SpfResult::TempError => {
                     info!(
-                        "{self}: {address}: SPF verification failed: temporary error: {:?}",
+                        "{self}: {address}: SPF validation failed: temporary error: {:?}",
                         output.explanation()
                     );
 
@@ -160,7 +163,7 @@ impl<S: AsyncReadWrite> Session<S> {
                 }
                 SpfResult::Fail | SpfResult::PermError | SpfResult::SoftFail => {
                     info!(
-                        "{self}: {address}: SPF verification failed: permanent error: {:?}",
+                        "{self}: {address}: SPF validation failed: permanent error: {:?}",
                         output.explanation()
                     );
 
@@ -185,6 +188,7 @@ impl<S: AsyncReadWrite> Session<S> {
         Ok(())
     }
 
+    /// Replies about failed reverse IP verification
     async fn verify_reverse_ip_reply(&mut self, permanent: bool, msg: &str) -> SessionResult<bool> {
         // Emit permanent errors only if in strict mode
         if permanent && self.cfg.verify_reverse_ip_strict {
@@ -202,6 +206,64 @@ impl<S: AsyncReadWrite> Session<S> {
         Ok(false)
     }
 
+    /// Checks if given PTR resolves back to the client's IP
+    async fn verify_reverse_ip_ptr(&mut self, ptr: Name) -> SessionResult<bool> {
+        let remote_ip = self.remote_ip;
+
+        match remote_ip {
+            IpAddr::V4(remote_ip_v4) => {
+                let lookup = match self.cfg.authenticator.resolver().ipv4_lookup(ptr).await {
+                    Ok(v) => v,
+                    Err(e) => {
+                        info!("{self}: reverse IP verification: PTR->IP lookup failed: {e:#}");
+                        return self
+                            .verify_reverse_ip_reply(
+                                is_error_negative_lookup(&e),
+                                "unable to look up IP for the PTR record",
+                            )
+                            .await;
+                    }
+                };
+
+                // Check if any of the addresses match the client's
+                if lookup
+                    .answers()
+                    .iter()
+                    .any(|x| x.data == RData::A(A(remote_ip_v4)))
+                {
+                    return Ok(true);
+                }
+            }
+
+            IpAddr::V6(remote_ip_v6) => {
+                let lookup = match self.cfg.authenticator.resolver().ipv6_lookup(ptr).await {
+                    Ok(v) => v,
+                    Err(e) => {
+                        info!("{self}: reverse IP verification: PTR->IP lookup failed: {e:#}");
+                        return self
+                            .verify_reverse_ip_reply(
+                                is_error_negative_lookup(&e),
+                                "unable to look up IP for the PTR record",
+                            )
+                            .await;
+                    }
+                };
+
+                // Check if any of the addresses match the client's
+                if lookup
+                    .answers()
+                    .iter()
+                    .any(|x| x.data == RData::AAAA(AAAA(remote_ip_v6)))
+                {
+                    return Ok(true);
+                }
+            }
+        };
+
+        Ok(false)
+    }
+
+    /// Verifies correctness of the client's reverse IP mapping
     async fn verify_reverse_ip(&mut self) -> SessionResult<bool> {
         let remote_ip = self.remote_ip;
 
@@ -239,70 +301,18 @@ impl<S: AsyncReadWrite> Session<S> {
 
         // Take max 3 PTRs from the response to avoid DoS.
         // Usually there should be only one anyway.
-        for ptr in lookup.answers().iter().take(3).filter_map(|r| {
-            let RData::PTR(ptr) = &r.data else {
-                return None;
-            };
-
-            Some(ptr.to_lowercase())
-        }) {
-            match remote_ip {
-                IpAddr::V4(remote_ip_v4) => {
-                    let lookup = match self.cfg.authenticator.resolver().ipv4_lookup(ptr).await {
-                        Ok(v) => v,
-                        Err(e) => {
-                            info!("{self}: reverse IP verification: PTR->IP lookup failed: {e:#}");
-                            return self
-                                .verify_reverse_ip_reply(
-                                    is_error_negative_lookup(&e),
-                                    "unable to look up IP for the PTR record",
-                                )
-                                .await;
-                        }
-                    };
-
-                    // Check if any of the addresses match the client's
-                    for v in lookup.answers().iter().filter_map(|r| {
-                        if let RData::A(a) = &r.data {
-                            Some(a.0)
-                        } else {
-                            None
-                        }
-                    }) {
-                        if v == remote_ip_v4 {
-                            return Ok(true);
-                        }
-                    }
-                }
-
-                IpAddr::V6(remote_ip_v6) => {
-                    let lookup = match self.cfg.authenticator.resolver().ipv6_lookup(ptr).await {
-                        Ok(v) => v,
-                        Err(e) => {
-                            info!("{self}: reverse IP verification: PTR->IP lookup failed: {e:#}");
-                            return self
-                                .verify_reverse_ip_reply(
-                                    is_error_negative_lookup(&e),
-                                    "unable to look up IP for the PTR record",
-                                )
-                                .await;
-                        }
-                    };
-
-                    // Check if any of the addresses match the client's
-                    for v in lookup.answers().iter().filter_map(|r| {
-                        if let RData::AAAA(a) = &r.data {
-                            Some(a.0)
-                        } else {
-                            None
-                        }
-                    }) {
-                        if v == remote_ip_v6 {
-                            return Ok(true);
-                        }
-                    }
-                }
-            };
+        for ptr in lookup
+            .answers()
+            .iter()
+            .filter_map(|r| match &r.data {
+                RData::PTR(ptr) => Some(ptr.to_lowercase()),
+                _ => None,
+            })
+            .take(3)
+        {
+            if self.verify_reverse_ip_ptr(ptr).await? {
+                return Ok(true);
+            }
         }
 
         info!(

--- a/ic-bn-lib/src/smtp/inbound/manager.rs
+++ b/ic-bn-lib/src/smtp/inbound/manager.rs
@@ -26,7 +26,9 @@ impl SessionManager {
         params: Arc<SessionConfig>,
         shutdown_token: CancellationToken,
     ) {
-        let mut session = Session::new(remote_addr.ip(), stream, params);
+        // Convert v6-mapped address to v4
+        let remote_ip = remote_addr.ip().to_canonical();
+        let mut session = Session::new(remote_ip, stream, params);
 
         match session.handle(shutdown_token.child_token()).await {
             Ok(v) => match v {
@@ -51,12 +53,15 @@ impl SessionManager {
         }
     }
 
-    /// Converts session into TLS mode
+    /// Converts session into TLS mode & runs it
     async fn starttls<S: AsyncReadWrite>(session: Session<S>, shutdown_token: CancellationToken) {
         let session_name = session.to_string();
 
+        debug!("{session_name}: starting TLS handshake");
         match session.into_tls().await {
             Ok(mut session) => {
+                debug!("{session}: TLS handshake succeeded");
+
                 if let Err(e) = session.handle(shutdown_token.child_token()).await {
                     if !matches!(e, SessionError::Quit) {
                         info!("{session}: error: {e:#}");

--- a/ic-bn-lib/src/smtp/inbound/mod.rs
+++ b/ic-bn-lib/src/smtp/inbound/mod.rs
@@ -528,7 +528,7 @@ mod tests {
                 ehlo_hostname: fqdn!("foo.bar"),
                 mail_from: "foo@bar".try_into().unwrap(),
                 rcpt_to: vec!["bar@baz".try_into().unwrap()],
-                body: b"012345678998765432100123456789".to_vec(),
+                body: "012345678998765432100123456789".into(),
             })
         );
     }
@@ -569,7 +569,7 @@ mod tests {
                 ehlo_hostname: fqdn!("foo.bar"),
                 mail_from: email!("foo@bar"),
                 rcpt_to: vec![email!("bar@baz")],
-                body: b"foobarmessage".to_vec(),
+                body: "foobarmessage".into(),
             })
         )
     }
@@ -613,7 +613,7 @@ mod tests {
                 ehlo_hostname: fqdn!("foo.bar"),
                 mail_from: email!("foo@bar"),
                 rcpt_to: vec![email!("dead@beef"), email!("dead@dead"), email!("bar@bax"),],
-                body: b"foobarmessage".to_vec(),
+                body: "foobarmessage".into(),
             })
         )
     }

--- a/ic-bn-lib/src/smtp/inbound/mod.rs
+++ b/ic-bn-lib/src/smtp/inbound/mod.rs
@@ -14,6 +14,7 @@ use std::{
 
 use bytes::Bytes;
 use fqdn::FQDN;
+use hickory_resolver::net::NetError;
 use ic_bn_lib_common::types::http::TlsInfo;
 use mail_auth::MessageAuthenticator;
 use rustls::ServerConfig;
@@ -43,6 +44,8 @@ pub enum SessionError {
     Io(#[from] io::Error),
     #[error("Fmt error: {0}")]
     Fmt(#[from] fmt::Error),
+    #[error("Dns error: {0}")]
+    Dns(#[from] NetError),
     #[error("Timed out")]
     Timeout,
     #[error("{0}")]

--- a/ic-bn-lib/src/smtp/inbound/mod.rs
+++ b/ic-bn-lib/src/smtp/inbound/mod.rs
@@ -110,6 +110,7 @@ pub struct SessionConfig {
     pub verify_ehlo_hostname: bool,
     pub verify_sender_domain: bool,
     pub verify_reverse_ip: bool,
+    pub verify_reverse_ip_strict: bool,
     pub verify_spf: bool,
     pub verify_dkim: bool,
     pub verify_dkim_strict: bool,
@@ -146,6 +147,7 @@ impl SessionConfig {
 
             verify_ehlo_hostname: false,
             verify_reverse_ip: false,
+            verify_reverse_ip_strict: false,
             verify_sender_domain: false,
             verify_spf: false,
             verify_dkim: false,
@@ -215,10 +217,11 @@ impl Default for SessionState {
 /// SMTP dynamic session data
 #[derive(Debug, Default)]
 pub struct SessionData {
-    pub ehlo_hostname: Option<FQDN>,
-    pub mail_from: Option<EmailAddress>,
-    pub rcpt_to: Vec<EmailAddress>,
-    pub message: Vec<u8>,
+    reverse_ip_verified: bool,
+    ehlo_hostname: Option<FQDN>,
+    mail_from: Option<EmailAddress>,
+    rcpt_to: Vec<EmailAddress>,
+    message: Vec<u8>,
 }
 
 /// SMTP session counters

--- a/ic-bn-lib/src/smtp/inbound/rcpt_to.rs
+++ b/ic-bn-lib/src/smtp/inbound/rcpt_to.rs
@@ -3,13 +3,14 @@ use std::{borrow::Cow, fmt::Write as _, str::FromStr};
 use smtp_proto::{
     RCPT_NOTIFY_DELAY, RCPT_NOTIFY_FAILURE, RCPT_NOTIFY_NEVER, RCPT_NOTIFY_SUCCESS, RcptTo,
 };
+use tracing::{debug, info};
 
 use crate::{
     network::AsyncReadWrite,
     smtp::{
         RecipientPolicy, RecipientResolveError,
         address::EmailAddress,
-        inbound::{Session, SessionResult},
+        inbound::{MAX_REPLY_LEN, Session, SessionResult},
     },
 };
 
@@ -32,6 +33,7 @@ impl<S: AsyncReadWrite> Session<S> {
         }
 
         let Ok(address) = EmailAddress::from_str(&to.address) else {
+            info!("{self}: {}: incorrect address", to.address);
             return self.reply("550", "5.1.2", "Incorrect address.").await;
         };
 
@@ -40,6 +42,7 @@ impl<S: AsyncReadWrite> Session<S> {
         }
 
         if self.data.rcpt_to.len() >= self.cfg.max_recipients {
+            info!("{self}: {}: too many recipients", to.address);
             return self.reply("455", "4.5.3", "Too many recipients.").await;
         }
 
@@ -49,20 +52,26 @@ impl<S: AsyncReadWrite> Session<S> {
             .resolve_recipient(mail_from, &address)
             .await
         {
-            Ok(v) => match v {
-                RecipientPolicy::Accept => {
-                    self.data.rcpt_to.push(address);
+            Ok(v) => {
+                debug!("{self}: {}: recipient resolved: {v}", to.address);
+
+                match v {
+                    RecipientPolicy::Accept => {
+                        self.data.rcpt_to.push(address);
+                    }
+                    RecipientPolicy::Rewrite(new_address) => {
+                        self.data.rcpt_to.push(new_address);
+                    }
+                    RecipientPolicy::Expand(additional_addresses) => {
+                        self.data.rcpt_to.push(address);
+                        self.data.rcpt_to.extend(additional_addresses);
+                    }
                 }
-                RecipientPolicy::Rewrite(new_address) => {
-                    self.data.rcpt_to.push(new_address);
-                }
-                RecipientPolicy::Expand(additional_addresses) => {
-                    self.data.rcpt_to.push(address);
-                    self.data.rcpt_to.extend(additional_addresses);
-                }
-            },
+            }
 
             Err(e) => {
+                info!("{self}: {}: recipient resolution error: {e:#}", to.address);
+
                 return match e {
                     RecipientResolveError::UnknownDomain => {
                         self.reply("550", "5.1.1", "Unknown recipient domain.")
@@ -71,11 +80,14 @@ impl<S: AsyncReadWrite> Session<S> {
                     RecipientResolveError::UnknownRecipient => {
                         self.reply("550", "5.1.2", "Mailbox does not exist.").await
                     }
-                    RecipientResolveError::Temporary(v) => {
+                    // Truncate the errors so that they don't overflow the reply buffer
+                    RecipientResolveError::Temporary(mut v) => {
+                        v.truncate(MAX_REPLY_LEN - 32);
                         self.reply_with("451", "4.4.3", |buf| write!(buf, "Temporary error: {v}"))
                             .await
                     }
-                    RecipientResolveError::Permanent(v) => {
+                    RecipientResolveError::Permanent(mut v) => {
+                        v.truncate(MAX_REPLY_LEN - 32);
                         self.reply_with("550", "5.1.3", |buf| write!(buf, "Permanent error: {v}"))
                             .await
                     }

--- a/ic-bn-lib/src/smtp/inbound/rcpt_to.rs
+++ b/ic-bn-lib/src/smtp/inbound/rcpt_to.rs
@@ -12,6 +12,7 @@ use crate::{
         address::EmailAddress,
         inbound::{MAX_REPLY_LEN, Session, SessionResult},
     },
+    truncate,
 };
 
 impl<S: AsyncReadWrite> Session<S> {
@@ -81,15 +82,17 @@ impl<S: AsyncReadWrite> Session<S> {
                         self.reply("550", "5.1.2", "Mailbox does not exist.").await
                     }
                     // Truncate the errors so that they don't overflow the reply buffer
-                    RecipientResolveError::Temporary(mut v) => {
-                        v.truncate(MAX_REPLY_LEN - 32);
-                        self.reply_with("451", "4.4.3", |buf| write!(buf, "Temporary error: {v}"))
-                            .await
+                    RecipientResolveError::Temporary(v) => {
+                        self.reply_with("451", "4.4.3", |buf| {
+                            write!(buf, "Temporary error: {}", truncate(&v, MAX_REPLY_LEN - 32))
+                        })
+                        .await
                     }
-                    RecipientResolveError::Permanent(mut v) => {
-                        v.truncate(MAX_REPLY_LEN - 32);
-                        self.reply_with("550", "5.1.3", |buf| write!(buf, "Permanent error: {v}"))
-                            .await
+                    RecipientResolveError::Permanent(v) => {
+                        self.reply_with("550", "5.1.3", |buf| {
+                            write!(buf, "Permanent error: {}", truncate(&v, MAX_REPLY_LEN - 32))
+                        })
+                        .await
                     }
                 };
             }

--- a/ic-bn-lib/src/smtp/inbound/session.rs
+++ b/ic-bn-lib/src/smtp/inbound/session.rs
@@ -471,7 +471,7 @@ impl<S: AsyncReadWrite> Session<S> {
 
             let signatures_passed = outputs
                 .iter()
-                .filter(|x| matches!(x.result(), DkimResult::Pass))
+                .filter(|x| matches!(x.result(), DkimResult::Pass | DkimResult::None))
                 .count();
 
             if strict {

--- a/ic-bn-lib/src/smtp/inbound/session.rs
+++ b/ic-bn-lib/src/smtp/inbound/session.rs
@@ -421,22 +421,28 @@ impl<S: AsyncReadWrite> Session<S> {
     #[allow(unreachable_code)]
     async fn verify_message(
         &mut self,
-        #[allow(unused_variables)] body: &[u8],
+        #[allow(unused_variables)] msg: &EmailMessage,
     ) -> SessionResult<bool> {
         #[cfg(test)]
         {
             return Ok(true);
         }
 
-        let Some(auth_message) = AuthenticatedMessage::parse(body) else {
-            info!("{self}: message parsing failed");
+        let Some(auth_message) = AuthenticatedMessage::parse(&msg.body) else {
+            info!(
+                "{self}: {}: {} -> {:?}: message parsing failed",
+                msg.ehlo_hostname, msg.mail_from, msg.rcpt_to
+            );
             self.reply("550", "5.7.7", "Failed to parse the message")
                 .await?;
             return Ok(false);
         };
 
         if auth_message.received_headers_count() > self.cfg.max_received_headers {
-            info!("{self}: message verification failed: too many 'Received' headers");
+            info!(
+                "{self}: {}: {} -> {:?}: message verification failed: too many 'Received' headers",
+                msg.ehlo_hostname, msg.mail_from, msg.rcpt_to
+            );
             self.reply(
                 "450",
                 "4.4.6",
@@ -459,12 +465,18 @@ impl<S: AsyncReadWrite> Session<S> {
                     .any(|x| matches!(x.result(), DkimResult::TempError(_)))
                 {
                     // If any of the signatures that failed with a temporary error - return temporary SMTP error code
-                    info!("{log_name}: DKIM verification temporary failure");
+                    info!(
+                        "{log_name}: {}: {} -> {:?}: DKIM verification temporary failure",
+                        msg.ehlo_hostname, msg.mail_from, msg.rcpt_to
+                    );
                     self.reply("451", "4.7.20", "DKIM validation temporary failure.")
                         .await
                 } else {
                     // Otherwise permanent
-                    info!("{log_name}: DKIM verification failure");
+                    info!(
+                        "{log_name}: {}: {} -> {:?}: DKIM verification failure",
+                        msg.ehlo_hostname, msg.mail_from, msg.rcpt_to
+                    );
                     self.reply("550", "5.7.20", "DKIM validation failed.").await
                 }
             };
@@ -490,7 +502,18 @@ impl<S: AsyncReadWrite> Session<S> {
 
             if signatures_passed > 0 {
                 debug!(
-                    "{log_name}: DKIM validation succeeded ({signatures_passed}/{} signatures passed)",
+                    "{log_name}: {}: {} -> {:?}: DKIM validation succeeded ({signatures_passed}/{} signatures passed)",
+                    msg.ehlo_hostname,
+                    msg.mail_from,
+                    msg.rcpt_to,
+                    outputs.len()
+                );
+            } else {
+                debug!(
+                    "{log_name}: {}: {} -> {:?}: DKIM validation succeeded ({signatures_passed}/{} signatures passed)",
+                    msg.ehlo_hostname,
+                    msg.mail_from,
+                    msg.rcpt_to,
                     outputs.len()
                 );
             }
@@ -509,22 +532,25 @@ impl<S: AsyncReadWrite> Session<S> {
 
         // SAFETY: Code makes sure these are all Some().
         // It's better to panic in tests if they are not.
-        let message = EmailMessage {
+        let msg = EmailMessage {
             id,
             ehlo_hostname: self.data.ehlo_hostname.clone().unwrap(),
             mail_from: self.data.mail_from.take().unwrap(),
             rcpt_to: std::mem::take(&mut self.data.rcpt_to),
-            body: std::mem::take(&mut self.data.message),
+            body: std::mem::take(&mut self.data.message).into(),
         };
 
         // Run configured verification steps on the message body
-        if !self.verify_message(&message.body).await? {
+        if !self.verify_message(&msg).await? {
             self.reset_message();
             return Ok(());
         }
 
-        if let Err(e) = self.cfg.delivery_agent.deliver_mail(message).await {
-            info!("{self}: message delivery failed: {e:#}");
+        if let Err(e) = self.cfg.delivery_agent.deliver_mail(msg.clone()).await {
+            info!(
+                "{self}: {}: {} -> {:?}: message delivery failed: {e:#}",
+                msg.ehlo_hostname, msg.mail_from, msg.rcpt_to
+            );
             self.reset_message();
 
             return match e {
@@ -543,7 +569,10 @@ impl<S: AsyncReadWrite> Session<S> {
             };
         }
 
-        info!("{self}: message ({message_size} bytes) queued with id {id}");
+        info!(
+            "{self}: {}: {} -> {:?}: message ({message_size} bytes) queued with id {id}",
+            msg.ehlo_hostname, msg.mail_from, msg.rcpt_to
+        );
         self.reply_with("250", "2.0.0", |buf| {
             write!(buf, "Message ({message_size} bytes) queued with id {id}")
         })

--- a/ic-bn-lib/src/smtp/inbound/session.rs
+++ b/ic-bn-lib/src/smtp/inbound/session.rs
@@ -17,6 +17,7 @@ use tokio::{
     select,
 };
 use tokio_util::{sync::CancellationToken, time::FutureExt};
+use tracing::{debug, info};
 use uuid::Uuid;
 
 use crate::{
@@ -51,6 +52,7 @@ impl<S: AsyncReadWrite> Session<S> {
 
         let mut buf = [0; MAX_REPLY_LEN];
         write!(&mut buf[..], "{code} {ext} {msg}\r\n").ok();
+        debug!("-> {code} {ext} {msg}");
         self.write(&buf[..len]).await
     }
 
@@ -74,6 +76,7 @@ impl<S: AsyncReadWrite> Session<S> {
             return self.write(b"\r\n").await;
         }
 
+        debug!("-> {buf}");
         write!(&mut buf, "\r\n")?;
         self.write(buf.as_bytes()).await
     }
@@ -163,26 +166,33 @@ impl<S: AsyncReadWrite> Session<S> {
     async fn handle_request(&mut self, req: Request<Cow<'_, str>>) -> SessionResult<()> {
         match req {
             Request::Ehlo { host } => {
+                debug!("{self}: <- EHLO {host}");
                 self.handle_ehlo(&host, true).await?;
             }
             Request::Helo { host } => {
+                debug!("{self}: <- HELO {host}");
                 self.handle_ehlo(&host, false).await?;
             }
             Request::Mail { from } => {
+                debug!("{self}: <- MAIL FROM: {}", from.address);
                 self.handle_mail_from(from).await?;
             }
             Request::Rcpt { to } => {
+                debug!("{self}: <- RCPT TO: {}", to.address);
                 self.handle_rcpt_to(to).await?;
             }
             Request::Rset => {
+                debug!("{self}: <- RSET");
                 self.reset_message();
                 self.reply("250", "2.0.0", "OK").await?;
             }
             Request::Quit => {
+                debug!("{self}: <- QUIT");
                 self.reply("221", "2.0.0", "Bye.").await?;
                 return Err(SessionError::Quit);
             }
             Request::Noop { .. } => {
+                debug!("{self}: <- NOOP");
                 self.reply("250", "2.0.0", "OK").await?;
             }
             _ => {
@@ -238,6 +248,7 @@ impl<S: AsyncReadWrite> Session<S> {
                         Ok(request) => match request {
                             // ASCII data
                             Request::Data => {
+                                debug!("{self}: <- DATA");
                                 if self.can_accept_message().await? {
                                     self.write(b"354 Start mail input; end with <CRLF>.<CRLF>\r\n")
                                         .await?;
@@ -251,6 +262,7 @@ impl<S: AsyncReadWrite> Session<S> {
                                 chunk_size,
                                 is_last,
                             } => {
+                                debug!("{self}: <- BDAT");
                                 // Check if we will be past max message limit with this chunk
                                 state = if self.data.message.len() + chunk_size
                                     > self.cfg.max_message_size
@@ -270,6 +282,7 @@ impl<S: AsyncReadWrite> Session<S> {
                                 }
                             }
                             Request::StartTls => {
+                                debug!("{self}: <- STARTTLS");
                                 if self.tls_info.is_some() {
                                     self.reply("504", "5.7.4", "Already in TLS mode.").await?;
                                     self.counters.errors += 1;
@@ -416,12 +429,14 @@ impl<S: AsyncReadWrite> Session<S> {
         }
 
         let Some(auth_message) = AuthenticatedMessage::parse(body) else {
+            info!("{self}: message parsing failed");
             self.reply("550", "5.7.7", "Failed to parse the message")
                 .await?;
             return Ok(false);
         };
 
         if auth_message.received_headers_count() > self.cfg.max_received_headers {
+            info!("{self}: message verification failed: too many 'Received' headers");
             self.reply(
                 "450",
                 "4.4.6",
@@ -435,6 +450,7 @@ impl<S: AsyncReadWrite> Session<S> {
             let outputs = self.cfg.authenticator.verify_dkim(&auth_message).await;
             // Make borrow checker happy
             let strict = self.cfg.verify_dkim_strict;
+            let log_name = self.to_string();
 
             // Replies with either a temporary or a permanent error code
             let mut reply = async || -> SessionResult<()> {
@@ -443,33 +459,40 @@ impl<S: AsyncReadWrite> Session<S> {
                     .any(|x| matches!(x.result(), DkimResult::TempError(_)))
                 {
                     // If any of the signatures that failed with a temporary error - return temporary SMTP error code
+                    info!("{log_name}: DKIM verification temporary failure");
                     self.reply("451", "4.7.20", "DKIM validation temporary failure.")
                         .await
                 } else {
                     // Otherwise permanent
+                    info!("{log_name}: DKIM verification failure");
                     self.reply("550", "5.7.20", "DKIM validation failed.").await
                 }
             };
 
+            let signatures_passed = outputs
+                .iter()
+                .filter(|x| matches!(x.result(), DkimResult::Pass))
+                .count();
+
             if strict {
                 // Check that *all* signatures have passed validation (or there are none)
-                if !outputs
-                    .iter()
-                    .all(|x| matches!(x.result(), DkimResult::Pass | DkimResult::None))
-                {
+                if outputs.len() != signatures_passed {
                     reply().await?;
                     return Ok(false);
                 }
             } else {
                 // Check if *any* of the signatures have passed validation (or there are none)
-                if !outputs.is_empty()
-                    && !outputs
-                        .iter()
-                        .any(|x| matches!(x.result(), DkimResult::Pass | DkimResult::None))
-                {
+                if !outputs.is_empty() && signatures_passed == 0 {
                     reply().await?;
                     return Ok(false);
                 }
+            }
+
+            if signatures_passed > 0 {
+                debug!(
+                    "{log_name}: DKIM validation succeeded ({signatures_passed}/{} signatures passed)",
+                    outputs.len()
+                );
             }
         }
 
@@ -501,6 +524,7 @@ impl<S: AsyncReadWrite> Session<S> {
         }
 
         if let Err(e) = self.cfg.delivery_agent.deliver_mail(message).await {
+            info!("{self}: message delivery failed: {e:#}");
             self.reset_message();
 
             return match e {
@@ -519,6 +543,7 @@ impl<S: AsyncReadWrite> Session<S> {
             };
         }
 
+        info!("{self}: message ({message_size} bytes) queued with id {id}");
         self.reply_with("250", "2.0.0", |buf| {
             write!(buf, "Message ({message_size} bytes) queued with id {id}")
         })

--- a/ic-bn-lib/src/smtp/mod.rs
+++ b/ic-bn-lib/src/smtp/mod.rs
@@ -3,6 +3,7 @@ use std::fmt::{Debug, Display};
 use async_trait::async_trait;
 use fqdn::FQDN;
 use itertools::Itertools;
+use strum::Display;
 use tracing::warn;
 use uuid::Uuid;
 
@@ -15,10 +16,13 @@ pub mod inbound;
 pub mod server;
 
 /// Recipient resolution policy
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Display)]
 pub enum RecipientPolicy {
+    #[strum(to_string = "Accept")]
     Accept,
+    #[strum(to_string = "Rewrite({0})")]
     Rewrite(EmailAddress),
+    #[strum(to_string = "Expand({0:?})")]
     Expand(Vec<EmailAddress>),
 }
 

--- a/ic-bn-lib/src/smtp/mod.rs
+++ b/ic-bn-lib/src/smtp/mod.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Debug, Display};
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use fqdn::FQDN;
 use itertools::Itertools;
 use strum::Display;
@@ -55,7 +56,7 @@ pub struct EmailMessage {
     pub ehlo_hostname: FQDN,
     pub mail_from: EmailAddress,
     pub rcpt_to: Vec<EmailAddress>,
-    pub body: Vec<u8>,
+    pub body: Bytes,
 }
 
 impl Display for EmailMessage {


### PR DESCRIPTION
* Fixes reverse DNS resolution problems (mostly due to v4-in-v6 mapped remote IPs), implement our own reverse IP verification to have more control over it
* Add attempts CLI DNS option
* Add `smtp_server_verify_reverse_ip_strict` option to control how strict we want it to be
* Fix SMTP mail parsing failure when the body is empty
* Fix detection when the canister doesn't speak SMTP & truncate errors to fit into reply
* Add a lot of debug/info logging