### PR TITLE
chore: bump dependencies to use reqwest 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = "0.1.83"
 axum = "0.8.1"
 candid = "0.10.10"
 clap = { version = "4.5.20", features = ["derive", "string", "env"] }
-cloudflare = { version = "0.14.0", default-features = false, features = [
+cloudflare = { git = "https://github.com/dfinity/cloudflare-rs", rev = "7d10dca3b339e8a29cb663341dbc802fe51bf322", default-features = false, features = [
     "rustls-tls",
 ] }
 derive-new = "0.7.0"
@@ -28,9 +28,9 @@ fqdn = { version = "0.5.2" }
 hickory-proto = "0.26.1"
 hickory-resolver = { version = "0.26.1", default-features = false, features = [
     "tokio",
-    "tls-ring",
-    "https-ring",
-    "dnssec-ring",
+    "tls-aws-lc-rs",
+    "https-aws-lc-rs",
+    "dnssec-aws-lc-rs",
     "webpki-roots",
 ] }
 http = "1.3.1"
@@ -39,13 +39,12 @@ http-body-util = "0.1.2"
 humantime = "2.2.0"
 hyper = "1.7.0"
 hyper-util = { version = "0.1.10", features = ["full"] }
-ic-agent = { version = "0.47", features = [
-    "ring",
+ic-agent = { version = "0.47.3", features = [
     "_internal_dynamic-routing",
 ] }
 ic-bn-lib-common = { version = "0.2", path = "./ic-bn-lib-common" }
-instant-acme = { version = "0.8.2", default-features = false, features = [
-    "ring",
+instant-acme = { version = "0.8.5", default-features = false, features = [
+    "aws-lc-rs",
     "hyper-rustls",
 ] }
 mail-auth = "0.9.0"
@@ -67,9 +66,14 @@ reqwest = { version = "0.13.2", default-features = false, features = [
 ] }
 rcgen = { version = "0.14.3" }
 rustls = { version = "0.23.18", default-features = false, features = [
-    "ring",
+    "aws_lc_rs",
     "std",
     "brotli",
+] }
+rustls-acme = { version = "0.15.1", default-features = false, features = [
+    "webpki-roots",
+    "tls12",
+    "aws-lc-rs",
 ] }
 serde = { version = "1.0.214", features = ["derive"] }
 smtp-proto = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,11 @@ reqwest = { version = "0.13.2", default-features = false, features = [
     "stream",
     "gzip",
 ] }
-rcgen = { version = "0.14.3" }
+rcgen = { version = "0.14.3", default-features = false, features = [
+    "crypto",
+    "pem",
+    "aws_lc_rs",
+] }
 rustls = { version = "0.23.18", default-features = false, features = [
     "aws_lc_rs",
     "std",

--- a/ic-bn-lib/Cargo.toml
+++ b/ic-bn-lib/Cargo.toml
@@ -66,7 +66,7 @@ hyper-rustls = { version = "0.27.5", optional = true, default-features = false, 
     "http2",
     "tls12",
     "native-tokio",
-    "ring",
+    "aws-lc-rs",
     "logging",
     "webpki-roots",
 ] }
@@ -89,15 +89,11 @@ rcgen = { workspace = true, optional = true }
 regex = "1.11.2"
 reqwest = { workspace = true }
 rustls = { version = "0.23.18", default-features = false, features = [
-    "ring",
+    "aws_lc_rs",
     "std",
     "brotli",
 ] }
-rustls-acme = { version = "0.15.1", default-features = false, features = [
-    "webpki-roots",
-    "tls12",
-    "ring",
-], optional = true }
+rustls-acme = { workspace = true, optional = true }
 rustls-pemfile = "2.2.0"
 rustls-platform-verifier = "0.7.0"
 scopeguard = "1.2.0"
@@ -125,7 +121,7 @@ tokio-util = { workspace = true }
 tokio-rustls = { version = "0.26.0", default-features = false, features = [
     "tls12",
     "logging",
-    "ring",
+    "aws-lc-rs",
 ] }
 tokio-io-timeout = "1.2.0"
 tower = { version = "0.5.1", features = ["util"] }

--- a/ic-bn-lib/src/smtp/inbound/mod.rs
+++ b/ic-bn-lib/src/smtp/inbound/mod.rs
@@ -751,7 +751,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_starttls() {
-        rustls::crypto::ring::default_provider()
+        rustls::crypto::aws_lc_rs::default_provider()
             .install_default()
             .ok();
 
@@ -833,7 +833,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_with_smtp_client() {
-        rustls::crypto::ring::default_provider()
+        rustls::crypto::aws_lc_rs::default_provider()
             .install_default()
             .ok();
 

--- a/ic-bn-lib/src/tls/acme/client.rs
+++ b/ic-bn-lib/src/tls/acme/client.rs
@@ -472,7 +472,7 @@ mod test {
     #[tokio::test]
     async fn test_acme_client() {
         // rustls 0.23+ requires a process-level CryptoProvider to be installed
-        let _ = rustls::crypto::ring::default_provider().install_default();
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         let pebble_env = Env::new().await;
 
         let tm = Arc::new(TokenManagerPebble::new(

--- a/ic-bn-lib/src/tls/acme/dns/mod.rs
+++ b/ic-bn-lib/src/tls/acme/dns/mod.rs
@@ -346,7 +346,7 @@ mod test {
     #[tokio::test]
     async fn test_acme_dns() {
         // rustls 0.23+ requires a process-level CryptoProvider to be installed
-        let _ = rustls::crypto::ring::default_provider().install_default();
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         let pebble_env = Env::new().await;
         let dir = tempdir().unwrap();
 

--- a/ic-bn-lib/src/tls/mod.rs
+++ b/ic-bn-lib/src/tls/mod.rs
@@ -20,7 +20,7 @@ use rustls::{
     ClientConfig, ServerConfig, SupportedProtocolVersion, TicketRotator,
     client::{ClientSessionMemoryCache, Resumption},
     compress::CompressionCache,
-    crypto::ring,
+    crypto::aws_lc_rs,
     server::ResolvesServerCert,
     sign::CertifiedKey,
 };
@@ -156,7 +156,7 @@ pub fn pem_convert_to_rustls_single(pem: &[u8]) -> Result<CertifiedKey, Error> {
     }
 
     // Parse private key
-    let key = ring::sign::any_supported_type(&key).context("unable to parse private key")?;
+    let key = aws_lc_rs::sign::any_supported_type(&key).context("unable to parse private key")?;
 
     Ok(CertifiedKey::new(certs, key))
 }
@@ -294,7 +294,7 @@ mod test {
     #[test]
     fn test_prepare_client_config() {
         // rustls 0.23+ requires a process-level CryptoProvider to be installed
-        let _ = rustls::crypto::ring::default_provider().install_default();
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         prepare_client_config(&[&rustls::version::TLS13, &rustls::version::TLS12]);
     }
 

--- a/ic-bn-lib/src/tls/verify.rs
+++ b/ic-bn-lib/src/tls/verify.rs
@@ -1,7 +1,9 @@
 use rustls::{
     DigitallySignedStruct,
     client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
-    crypto::{WebPkiSupportedAlgorithms, ring, verify_tls12_signature, verify_tls13_signature},
+    crypto::{
+        WebPkiSupportedAlgorithms, aws_lc_rs, verify_tls12_signature, verify_tls13_signature,
+    },
     pki_types::{CertificateDer, ServerName, UnixTime},
 };
 
@@ -12,7 +14,7 @@ pub struct NoopServerCertVerifier(WebPkiSupportedAlgorithms);
 
 impl Default for NoopServerCertVerifier {
     fn default() -> Self {
-        Self(ring::default_provider().signature_verification_algorithms)
+        Self(aws_lc_rs::default_provider().signature_verification_algorithms)
     }
 }
 


### PR DESCRIPTION
This PR bumps dependencies so that only reqwest 0.13 is used in the dependency tree. The motivation for this change is that reqwest 0.12 and reqwest 0.13 cannot be used in the dependency tree at the same time without a ton of boilerplate code.