### PR TITLE
fix: Don't use git for cloudflare

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,9 @@ async-trait = "0.1.83"
 axum = "0.8.1"
 candid = "0.10.10"
 clap = { version = "4.5.20", features = ["derive", "string", "env"] }
-cloudflare = { git = "https://github.com/dfinity/cloudflare-rs", rev = "7d10dca3b339e8a29cb663341dbc802fe51bf322", default-features = false, features = [
+# Lock it down for now so that our fork (which has 0.14.1)
+# is selected during patching in ic-gateway etc
+cloudflare = { version = "<=0.14.1", default-features = false, features = [
     "rustls-tls",
 ] }
 derive-new = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ candid = "0.10.10"
 clap = { version = "4.5.20", features = ["derive", "string", "env"] }
 # Lock it down for now so that our fork (which has 0.14.1)
 # is selected during patching in ic-gateway etc
-cloudflare = { version = "<=0.14.1", default-features = false, features = [
+cloudflare = { version = ">=0.14.0,<=0.14.1", default-features = false, features = [
     "rustls-tls",
 ] }
 derive-new = "0.7.0"


### PR DESCRIPTION
git dependency prevents publishing to crates.io, we'll have to use cargo patching in `ic-gateway` & monorepo instead