### PR TITLE
Don't use const for EWMA::get()

### DIFF
--- a/ic-bn-lib/src/http/shed/ewma.rs
+++ b/ic-bn-lib/src/http/shed/ewma.rs
@@ -32,7 +32,7 @@ impl EWMA {
     }
 
     /// Get the average
-    pub const fn get(&self) -> Option<f64> {
+    pub fn get(&self) -> Option<f64> {
         if self.new {
             return None;
         }
@@ -92,7 +92,7 @@ impl DEWMA {
     }
 
     /// Get the average
-    pub const fn get(&self, m: f64) -> Option<f64> {
+    pub fn get(&self, m: f64) -> Option<f64> {
         // The function is undefined for the 1st measurement
         if self.iter < 2 {
             return None;


### PR DESCRIPTION
Using `const` means that `std::f64::<impl f64>::mul_add` has to be `const` as well, which was only standardized in Rust 1.94. Rust toolchains older than this will fail with the following:

> `std::f64::<impl f64>::mul_add` is not yet stable as a const fn

See also: https://github.com/rust-lang/rust/issues/146724