### PR TITLE
feat(NODE-1967): Add domain flags

### DIFF
--- a/ic-bn-lib-common/Cargo.toml
+++ b/ic-bn-lib-common/Cargo.toml
@@ -5,7 +5,7 @@ license.workspace = true
 readme.workspace = true
 keywords.workspace = true
 description = "A collection of traits & types commonly used by ic-bn-lib and others"
-version = "0.2.2"
+version = "0.2.4"
 documentation = "https://docs.rs/ic-bn-lib-common"
 
 [dependencies]

--- a/ic-bn-lib-common/src/types/mod.rs
+++ b/ic-bn-lib-common/src/types/mod.rs
@@ -22,7 +22,7 @@ pub const FLAG_PRERENDER: DomainFlag = DomainFlag(1 << 0);
 /// Used only in tests
 pub const FLAG_TEST: DomainFlag = DomainFlag(1 << 31);
 
-const FLAGS: [DomainFlag; 2] = [FLAG_PRERENDER, FLAG_TEST];
+const FLAGS: [(DomainFlag, &str); 2] = [(FLAG_PRERENDER, "prerender"), (FLAG_TEST, "test")];
 
 /// Single flag
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -32,25 +32,25 @@ impl FromStr for DomainFlag {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "prerender" => FLAG_PRERENDER,
-            "test" => FLAG_TEST,
-            _ => return Err(anyhow!("unknown flag {s}").into()),
-        })
+        for (flag, name) in FLAGS {
+            if s == name {
+                return Ok(flag);
+            }
+        }
+
+        Err(anyhow!("unknown flag {s}").into())
     }
 }
 
 impl Display for DomainFlag {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match *self {
-                FLAG_PRERENDER => "prerender",
-                FLAG_TEST => "test",
-                _ => "unknown",
+        for (flag, name) in FLAGS {
+            if *self == flag {
+                return write!(f, "{}", name);
             }
-        )
+        }
+
+        write!(f, "unknown")
     }
 }
 
@@ -79,10 +79,6 @@ impl DomainFlags {
     pub fn unset_flag(&mut self, f: DomainFlag) {
         self.0 &= !f.0;
     }
-
-    pub fn merge(&mut self, other: DomainFlags) {
-        self.0 |= other.0;
-    }
 }
 
 impl BitOrAssign<DomainFlag> for DomainFlags {
@@ -107,11 +103,11 @@ impl FromStr for DomainFlags {
 
 impl Display for DomainFlags {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut flags = vec![];
+        let mut flags = Vec::with_capacity(self.0.count_ones() as usize);
 
-        for flag in FLAGS {
+        for (flag, name) in FLAGS {
             if self.has_flag(flag) {
-                flags.push(flag.to_string());
+                flags.push(name);
             }
         }
 
@@ -240,9 +236,8 @@ impl RequestType {
 mod tests {
     use fqdn::fqdn;
 
-    use crate::principal;
-
     use super::*;
+    use crate::principal;
 
     #[test]
     fn test_custom_domain_flags() {
@@ -268,11 +263,6 @@ mod tests {
             DomainFlags::new([FLAG_PRERENDER, FLAG_TEST]).to_string(),
             "prerender, test"
         );
-
-        let mut flags = DomainFlags::new([FLAG_TEST]);
-        flags.merge(DomainFlags::new([FLAG_PRERENDER]));
-        assert!(flags.has_flag(FLAG_PRERENDER));
-        assert!(flags.has_flag(FLAG_TEST));
 
         let flags = DomainFlags::from_str("test|prerender").unwrap();
         assert!(flags.has_flag(FLAG_PRERENDER));

--- a/ic-bn-lib-common/src/types/mod.rs
+++ b/ic-bn-lib-common/src/types/mod.rs
@@ -20,6 +20,11 @@ use crate::Error;
 /// through the pre-rendering service.
 pub const FLAG_PRERENDER: DomainFlag = DomainFlag(1 << 0);
 
+/// Used only in tests
+const FLAG_TEST: DomainFlag = DomainFlag(1 << 31);
+
+const FLAGS: [DomainFlag; 2] = [FLAG_PRERENDER, FLAG_TEST];
+
 /// Single flag
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DomainFlag(u32);
@@ -30,6 +35,7 @@ impl FromStr for DomainFlag {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
             "prerender" => FLAG_PRERENDER,
+            "test" => FLAG_TEST,
             _ => return Err(anyhow!("unknown flag {s}").into()),
         })
     }
@@ -42,6 +48,7 @@ impl Display for DomainFlag {
             "{}",
             match *self {
                 FLAG_PRERENDER => "prerender",
+                FLAG_TEST => "test",
                 _ => "unknown",
             }
         )
@@ -63,7 +70,7 @@ impl DomainFlags {
     }
 
     pub fn has_flag(&self, f: DomainFlag) -> bool {
-        self.0 & f.0 == 1
+        self.0 & f.0 != 0
     }
 
     pub fn set_flag(&mut self, f: DomainFlag) {
@@ -72,6 +79,10 @@ impl DomainFlags {
 
     pub fn unset_flag(&mut self, f: DomainFlag) {
         self.0 &= !f.0;
+    }
+
+    pub fn merge(&mut self, other: DomainFlags) {
+        self.0 |= other.0;
     }
 }
 
@@ -87,10 +98,8 @@ impl FromStr for DomainFlags {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut flags = Self::default();
         for x in s.split('|') {
-            match x {
-                "prerender" => flags |= FLAG_PRERENDER,
-                _ => return Err(anyhow!("unknown flag {x}").into()),
-            }
+            let flag = DomainFlag::from_str(x)?;
+            flags.set_flag(flag);
         }
 
         Ok(flags)
@@ -100,8 +109,11 @@ impl FromStr for DomainFlags {
 impl Display for DomainFlags {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut flags = vec![];
-        if self.0 & FLAG_PRERENDER.0 == 1 {
-            flags.push("prerender");
+
+        for flag in FLAGS {
+            if self.has_flag(flag) {
+                flags.push(flag.to_string());
+            }
         }
 
         write!(f, "{}", flags.join(", "))
@@ -234,5 +246,21 @@ mod tests {
         cd = cd.unset_flag(FLAG_PRERENDER);
         assert_eq!(cd.flags.unwrap().0, 0b10010001000000001001000100000000);
         assert!(!cd.has_flag(FLAG_PRERENDER));
+
+        assert_eq!(
+            DomainFlags::new([FLAG_PRERENDER, FLAG_TEST]).to_string(),
+            "prerender, test"
+        );
+
+        let mut flags = DomainFlags::new([FLAG_TEST]);
+        flags.merge(DomainFlags::new([FLAG_PRERENDER]));
+        assert!(flags.has_flag(FLAG_PRERENDER));
+        assert!(flags.has_flag(FLAG_TEST));
+
+        let flags = DomainFlags::from_str("test|prerender").unwrap();
+        assert!(flags.has_flag(FLAG_PRERENDER));
+        assert!(flags.has_flag(FLAG_TEST));
+
+        assert!(DomainFlags::from_str("test|prerender|foo").is_err());
     }
 }

--- a/ic-bn-lib-common/src/types/mod.rs
+++ b/ic-bn-lib-common/src/types/mod.rs
@@ -19,9 +19,8 @@ use crate::Error;
 /// Flag that signifies that this domain should be passed
 /// through the pre-rendering service.
 pub const FLAG_PRERENDER: DomainFlag = DomainFlag(1 << 0);
-
 /// Used only in tests
-const FLAG_TEST: DomainFlag = DomainFlag(1 << 31);
+pub const FLAG_TEST: DomainFlag = DomainFlag(1 << 31);
 
 const FLAGS: [DomainFlag; 2] = [FLAG_PRERENDER, FLAG_TEST];
 

--- a/ic-bn-lib-common/src/types/mod.rs
+++ b/ic-bn-lib-common/src/types/mod.rs
@@ -126,6 +126,7 @@ pub struct CustomDomain {
     pub canister_id: Principal,
     /// Opaque timestamp to reflect when the domain was created, can be zero
     pub timestamp: u64,
+    pub priority: u8,
     pub flags: Option<DomainFlags>,
 }
 
@@ -135,6 +136,7 @@ impl CustomDomain {
             name,
             canister_id,
             timestamp: 0,
+            priority: 0,
             flags: None,
         }
     }
@@ -143,7 +145,24 @@ impl CustomDomain {
         self.flags.is_some_and(|x| x.0 & flag.0 == 1)
     }
 
-    pub fn set_flag(mut self, flag: DomainFlag) -> Self {
+    pub fn set_flag(&mut self, flag: DomainFlag) {
+        match &mut self.flags {
+            Some(v) => v.set_flag(flag),
+            None => self.flags = Some(DomainFlags::new([flag])),
+        }
+    }
+
+    pub fn unset_flag(&mut self, flag: DomainFlag) {
+        if let Some(v) = &mut self.flags {
+            v.unset_flag(flag)
+        }
+    }
+
+    pub fn set_priority(&mut self, prio: u8) {
+        self.priority = prio;
+    }
+
+    pub fn with_flag(mut self, flag: DomainFlag) -> Self {
         match &mut self.flags {
             Some(v) => v.set_flag(flag),
             None => self.flags = Some(DomainFlags::new([flag])),
@@ -152,10 +171,8 @@ impl CustomDomain {
         self
     }
 
-    pub fn unset_flag(mut self, flag: DomainFlag) -> Self {
-        if let Some(v) = &mut self.flags {
-            v.unset_flag(flag)
-        }
+    pub fn with_priority(mut self, prio: u8) -> Self {
+        self.priority = prio;
         self
     }
 }
@@ -234,15 +251,16 @@ mod tests {
             canister_id: principal!("aaaaa-aa"),
             timestamp: 0,
             flags: Some(DomainFlags(0b10010001000000001001000100000000)),
+            priority: 0,
         };
 
         assert!(!cd.has_flag(FLAG_PRERENDER));
 
-        cd = cd.set_flag(FLAG_PRERENDER);
+        cd.set_flag(FLAG_PRERENDER);
         assert_eq!(cd.flags.unwrap().0, 0b10010001000000001001000100000001);
         assert!(cd.has_flag(FLAG_PRERENDER));
 
-        cd = cd.unset_flag(FLAG_PRERENDER);
+        cd.unset_flag(FLAG_PRERENDER);
         assert_eq!(cd.flags.unwrap().0, 0b10010001000000001001000100000000);
         assert!(!cd.has_flag(FLAG_PRERENDER));
 

--- a/ic-bn-lib-common/src/types/mod.rs
+++ b/ic-bn-lib-common/src/types/mod.rs
@@ -6,10 +6,107 @@ pub mod tls;
 pub mod utils;
 pub mod vector;
 
+use std::{fmt::Display, ops::BitOrAssign, str::FromStr};
+
+use anyhow::anyhow;
 use candid::Principal;
 use fqdn::FQDN;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString, IntoStaticStr};
+
+use crate::Error;
+
+/// Flag that signifies that this domain should be passed
+/// through the pre-rendering service.
+pub const FLAG_PRERENDER: DomainFlag = DomainFlag(1 << 0);
+
+/// Single flag
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DomainFlag(u32);
+
+impl FromStr for DomainFlag {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "prerender" => FLAG_PRERENDER,
+            _ => return Err(anyhow!("unknown flag {s}").into()),
+        })
+    }
+}
+
+impl Display for DomainFlag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match *self {
+                FLAG_PRERENDER => "prerender",
+                _ => "unknown",
+            }
+        )
+    }
+}
+
+/// Bitmask with flags
+#[derive(Clone, Default, Copy, Debug, PartialEq, Eq)]
+pub struct DomainFlags(u32);
+
+impl DomainFlags {
+    pub fn new(flags_in: impl IntoIterator<Item = DomainFlag>) -> Self {
+        let mut flags = Self::default();
+        for x in flags_in.into_iter() {
+            flags.set_flag(x);
+        }
+
+        flags
+    }
+
+    pub fn has_flag(&self, f: DomainFlag) -> bool {
+        self.0 & f.0 == 1
+    }
+
+    pub fn set_flag(&mut self, f: DomainFlag) {
+        *self |= f
+    }
+
+    pub fn unset_flag(&mut self, f: DomainFlag) {
+        self.0 &= !f.0;
+    }
+}
+
+impl BitOrAssign<DomainFlag> for DomainFlags {
+    fn bitor_assign(&mut self, rhs: DomainFlag) {
+        self.0 |= rhs.0;
+    }
+}
+
+impl FromStr for DomainFlags {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut flags = Self::default();
+        for x in s.split('|') {
+            match x {
+                "prerender" => flags |= FLAG_PRERENDER,
+                _ => return Err(anyhow!("unknown flag {x}").into()),
+            }
+        }
+
+        Ok(flags)
+    }
+}
+
+impl Display for DomainFlags {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut flags = vec![];
+        if self.0 & FLAG_PRERENDER.0 == 1 {
+            flags.push("prerender");
+        }
+
+        write!(f, "{}", flags.join(", "))
+    }
+}
 
 /// Represents a custom domain with a corresponding canister ID
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -18,6 +115,38 @@ pub struct CustomDomain {
     pub canister_id: Principal,
     /// Opaque timestamp to reflect when the domain was created, can be zero
     pub timestamp: u64,
+    pub flags: Option<DomainFlags>,
+}
+
+impl CustomDomain {
+    pub fn new(name: FQDN, canister_id: Principal) -> Self {
+        Self {
+            name,
+            canister_id,
+            timestamp: 0,
+            flags: None,
+        }
+    }
+
+    pub fn has_flag(&self, flag: DomainFlag) -> bool {
+        self.flags.is_some_and(|x| x.0 & flag.0 == 1)
+    }
+
+    pub fn set_flag(mut self, flag: DomainFlag) -> Self {
+        match &mut self.flags {
+            Some(v) => v.set_flag(flag),
+            None => self.flags = Some(DomainFlags::new([flag])),
+        }
+
+        self
+    }
+
+    pub fn unset_flag(mut self, flag: DomainFlag) -> Self {
+        if let Some(v) = &mut self.flags {
+            v.unset_flag(flag)
+        }
+        self
+    }
 }
 
 /// Type of IC API request
@@ -76,5 +205,34 @@ impl RequestType {
                 | Self::ReadStateSubnetV2
                 | Self::ReadStateSubnetV3
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fqdn::fqdn;
+
+    use crate::principal;
+
+    use super::*;
+
+    #[test]
+    fn test_custom_domain_flags() {
+        let mut cd = CustomDomain {
+            name: fqdn!("foo"),
+            canister_id: principal!("aaaaa-aa"),
+            timestamp: 0,
+            flags: Some(DomainFlags(0b10010001000000001001000100000000)),
+        };
+
+        assert!(!cd.has_flag(FLAG_PRERENDER));
+
+        cd = cd.set_flag(FLAG_PRERENDER);
+        assert_eq!(cd.flags.unwrap().0, 0b10010001000000001001000100000001);
+        assert!(cd.has_flag(FLAG_PRERENDER));
+
+        cd = cd.unset_flag(FLAG_PRERENDER);
+        assert_eq!(cd.flags.unwrap().0, 0b10010001000000001001000100000000);
+        assert!(!cd.has_flag(FLAG_PRERENDER));
     }
 }

--- a/ic-bn-lib-common/src/types/mod.rs
+++ b/ic-bn-lib-common/src/types/mod.rs
@@ -93,7 +93,7 @@ impl FromStr for DomainFlags {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut flags = Self::default();
         for x in s.split('|') {
-            let flag = DomainFlag::from_str(x)?;
+            let flag = DomainFlag::from_str(x.trim())?;
             flags.set_flag(flag);
         }
 
@@ -264,7 +264,7 @@ mod tests {
             "prerender|test"
         );
 
-        let flags = DomainFlags::from_str("test|prerender").unwrap();
+        let flags = DomainFlags::from_str("test | prerender").unwrap();
         assert!(flags.has_flag(FLAG_PRERENDER));
         assert!(flags.has_flag(FLAG_TEST));
 

--- a/ic-bn-lib-common/src/types/mod.rs
+++ b/ic-bn-lib-common/src/types/mod.rs
@@ -111,7 +111,7 @@ impl Display for DomainFlags {
             }
         }
 
-        write!(f, "{}", flags.join(", "))
+        write!(f, "{}", flags.join("|"))
     }
 }
 
@@ -138,7 +138,7 @@ impl CustomDomain {
     }
 
     pub fn has_flag(&self, flag: DomainFlag) -> bool {
-        self.flags.is_some_and(|x| x.0 & flag.0 == 1)
+        self.flags.is_some_and(|x| x.has_flag(flag))
     }
 
     pub fn set_flag(&mut self, flag: DomainFlag) {
@@ -261,7 +261,7 @@ mod tests {
 
         assert_eq!(
             DomainFlags::new([FLAG_PRERENDER, FLAG_TEST]).to_string(),
-            "prerender, test"
+            "prerender|test"
         );
 
         let flags = DomainFlags::from_str("test|prerender").unwrap();

--- a/ic-bn-lib/src/custom_domains/mod.rs
+++ b/ic-bn-lib/src/custom_domains/mod.rs
@@ -76,6 +76,7 @@ async fn get_custom_domains_from_url(
     cli: &Arc<dyn Client>,
     url: &Url,
     timeout: Duration,
+    priority: u8,
     flags: Option<DomainFlags>,
 ) -> Result<Vec<CustomDomain>, Error> {
     let body = get_url_body(cli, url, timeout)
@@ -99,6 +100,7 @@ async fn get_custom_domains_from_url(
             name: k,
             canister_id: v,
             timestamp: 0,
+            priority,
             flags,
         })
         .collect::<Vec<_>>())
@@ -110,6 +112,7 @@ pub struct GenericProvider {
     http_client: Arc<dyn Client>,
     url: Url,
     timeout: Duration,
+    priority: u8,
     flags: Option<DomainFlags>,
 }
 
@@ -122,7 +125,14 @@ impl Debug for GenericProvider {
 #[async_trait]
 impl ProvidesCustomDomains for GenericProvider {
     async fn get_custom_domains(&self) -> Result<Vec<CustomDomain>, Error> {
-        get_custom_domains_from_url(&self.http_client, &self.url, self.timeout, self.flags).await
+        get_custom_domains_from_url(
+            &self.http_client,
+            &self.url,
+            self.timeout,
+            self.priority,
+            self.flags,
+        )
+        .await
     }
 }
 
@@ -140,6 +150,7 @@ pub struct GenericProviderTimestamped {
     http_client: Arc<dyn Client>,
     url: Url,
     timeout: Duration,
+    priority: u8,
     flags: Option<DomainFlags>,
     #[new(default)]
     timestamp: AtomicU64,
@@ -185,10 +196,15 @@ impl ProvidesCustomDomains for GenericProviderTimestamped {
         };
 
         // Otherwise fetch a fresh version from the provided URL
-        let domains =
-            get_custom_domains_from_url(&self.http_client, &domains_url, self.timeout, self.flags)
-                .await
-                .context("unable to fetch custom domains")?;
+        let domains = get_custom_domains_from_url(
+            &self.http_client,
+            &domains_url,
+            self.timeout,
+            self.priority,
+            self.flags,
+        )
+        .await
+        .context("unable to fetch custom domains")?;
 
         warn!("{self:?}: new timestamp, got {} domains", domains.len());
 
@@ -247,6 +263,7 @@ pub struct GenericProviderDiff {
     http_client: Arc<dyn Client>,
     url: Url,
     timeout: Duration,
+    priority: u8,
     flags: Option<DomainFlags>,
     #[new(default)]
     timestamp: AtomicU64,
@@ -290,6 +307,7 @@ impl GenericProviderDiff {
                 name,
                 canister_id,
                 timestamp: 0,
+                priority: self.priority,
                 flags: self.flags,
             })
             .collect()
@@ -360,6 +378,7 @@ impl ProvidesCustomDomains for GenericProviderDiff {
 #[derive(new)]
 pub struct LocalFileProvider {
     file_path: PathBuf,
+    priority: u8,
     flags: Option<DomainFlags>,
 }
 
@@ -405,6 +424,7 @@ impl ProvidesCustomDomains for LocalFileProvider {
                 name,
                 canister_id,
                 timestamp: 0,
+                priority: self.priority,
                 flags: self.flags,
             });
         }
@@ -566,6 +586,7 @@ mod test {
             cli,
             "http://foo".try_into().unwrap(),
             Duration::ZERO,
+            0,
             Some(DomainFlags::new([FLAG_PRERENDER])),
         );
 
@@ -582,12 +603,12 @@ mod test {
             domains,
             vec![
                 CustomDomain::new(fqdn!("foo.bar2"), principal!("qoctq-giaaa-aaaaa-aaaea-cai"))
-                    .set_flag(FLAG_PRERENDER),
+                    .with_flag(FLAG_PRERENDER),
                 CustomDomain::new(
                     fqdn!("2athis-domain-is-exactly-fifty-one-characters-l.com"),
                     principal!("aaaaa-aa"),
                 )
-                .set_flag(FLAG_PRERENDER)
+                .with_flag(FLAG_PRERENDER)
             ]
         );
 
@@ -604,11 +625,11 @@ mod test {
             domains,
             vec![
                 CustomDomain::new(fqdn!("foo.bar2"), principal!("qoctq-giaaa-aaaaa-aaaea-cai"))
-                    .set_flag(FLAG_PRERENDER),
+                    .with_flag(FLAG_PRERENDER),
                 CustomDomain::new(fqdn!("foo.bar3"), principal!("aaaaa-aa"))
-                    .set_flag(FLAG_PRERENDER),
+                    .with_flag(FLAG_PRERENDER),
                 CustomDomain::new(fqdn!("foo.bar4"), principal!("qoctq-giaaa-aaaaa-aaaea-cai"))
-                    .set_flag(FLAG_PRERENDER),
+                    .with_flag(FLAG_PRERENDER),
             ]
         );
 
@@ -625,7 +646,7 @@ mod test {
             domains,
             vec![
                 CustomDomain::new(fqdn!("foo.bar5"), principal!("qoctq-giaaa-aaaaa-aaaea-cai"))
-                    .set_flag(FLAG_PRERENDER)
+                    .with_flag(FLAG_PRERENDER)
             ]
         );
     }
@@ -637,6 +658,7 @@ mod test {
             cli,
             "http://foo".try_into().unwrap(),
             Duration::ZERO,
+            0,
             Some(DomainFlags::new([FLAG_PRERENDER])),
         );
 
@@ -653,12 +675,12 @@ mod test {
             domains,
             vec![
                 CustomDomain::new(fqdn!("bar.foo"), principal!("qoctq-giaaa-aaaaa-aaaea-cai"))
-                    .set_flag(FLAG_PRERENDER),
+                    .with_flag(FLAG_PRERENDER),
                 CustomDomain::new(
                     fqdn!("2athis-domain-is-exactly-fifty-one-characters-l.com"),
                     principal!("aaaaa-aa")
                 )
-                .set_flag(FLAG_PRERENDER),
+                .with_flag(FLAG_PRERENDER),
             ]
         );
 
@@ -675,12 +697,12 @@ mod test {
             domains,
             vec![
                 CustomDomain::new(fqdn!("bar.foo"), principal!("qoctq-giaaa-aaaaa-aaaea-cai"))
-                    .set_flag(FLAG_PRERENDER),
+                    .with_flag(FLAG_PRERENDER),
                 CustomDomain::new(
                     fqdn!("2athis-domain-is-exactly-fifty-one-characters-l.com"),
                     principal!("aaaaa-aa")
                 )
-                .set_flag(FLAG_PRERENDER)
+                .with_flag(FLAG_PRERENDER)
             ]
         );
 
@@ -697,9 +719,9 @@ mod test {
             domains,
             vec![
                 CustomDomain::new(fqdn!("bar.foos"), principal!("qoctq-giaaa-aaaaa-aaaea-cai"))
-                    .set_flag(FLAG_PRERENDER),
+                    .with_flag(FLAG_PRERENDER),
                 CustomDomain::new(fqdn!("foo.barr"), principal!("aaaaa-aa"))
-                    .set_flag(FLAG_PRERENDER)
+                    .with_flag(FLAG_PRERENDER)
             ]
         );
 
@@ -716,9 +738,9 @@ mod test {
             domains,
             vec![
                 CustomDomain::new(fqdn!("bar.foos"), principal!("qoctq-giaaa-aaaaa-aaaea-cai"))
-                    .set_flag(FLAG_PRERENDER),
+                    .with_flag(FLAG_PRERENDER),
                 CustomDomain::new(fqdn!("foo.barr"), principal!("aaaaa-aa"))
-                    .set_flag(FLAG_PRERENDER),
+                    .with_flag(FLAG_PRERENDER),
             ]
         );
     }
@@ -730,6 +752,7 @@ mod test {
             cli,
             "http://foo:bar@foo/beef".try_into().unwrap(),
             Duration::ZERO,
+            0,
             Some(DomainFlags::new([FLAG_PRERENDER])),
         );
 
@@ -745,23 +768,33 @@ mod test {
             domains,
             vec![
                 CustomDomain::new(fqdn!("foo.bar"), principal!("aaaaa-aa"))
-                    .set_flag(FLAG_PRERENDER),
+                    .with_flag(FLAG_PRERENDER),
                 CustomDomain::new(
                     fqdn!("2athis-domain-is-exactly-fifty-one-characters-l.com"),
                     principal!("qoctq-giaaa-aaaaa-aaaea-cai")
                 )
-                .set_flag(FLAG_PRERENDER),
+                .with_flag(FLAG_PRERENDER),
             ]
         );
 
         let cli = Arc::new(MockClientBadDomain);
-        let prov =
-            GenericProvider::new(cli, "http://foo".try_into().unwrap(), Duration::ZERO, None);
+        let prov = GenericProvider::new(
+            cli,
+            "http://foo".try_into().unwrap(),
+            Duration::ZERO,
+            0,
+            None,
+        );
         assert!(prov.get_custom_domains().await.is_err());
 
         let cli = Arc::new(MockClientBadCanister);
-        let prov =
-            GenericProvider::new(cli, "http://foo".try_into().unwrap(), Duration::ZERO, None);
+        let prov = GenericProvider::new(
+            cli,
+            "http://foo".try_into().unwrap(),
+            Duration::ZERO,
+            0,
+            None,
+        );
         assert!(prov.get_custom_domains().await.is_err());
     }
 
@@ -782,6 +815,7 @@ mod test {
 
         let prov = LocalFileProvider::new(
             temp_file.path().to_path_buf(),
+            0,
             Some(DomainFlags::new([FLAG_PRERENDER])),
         );
         let mut domains: Vec<CustomDomain> = prov.get_custom_domains().await.unwrap();
@@ -792,17 +826,17 @@ mod test {
             domains,
             vec![
                 CustomDomain::new(fqdn!("foo.bar"), principal!("aaaaa-aa"))
-                    .set_flag(FLAG_PRERENDER),
+                    .with_flag(FLAG_PRERENDER),
                 CustomDomain::new(
                     fqdn!("test.example.com"),
                     principal!("qoctq-giaaa-aaaaa-aaaea-cai"),
                 )
-                .set_flag(FLAG_PRERENDER),
+                .with_flag(FLAG_PRERENDER),
                 CustomDomain::new(
                     fqdn!("2athis-domain-is-exactly-fifty-one-characters-l.com"),
                     principal!("ryjl3-tyaaa-aaaaa-aaaba-cai"),
                 )
-                .set_flag(FLAG_PRERENDER),
+                .with_flag(FLAG_PRERENDER),
             ]
         );
     }
@@ -816,7 +850,7 @@ mod test {
         writeln!(temp_file, "foo.bar aaaaa-aa").unwrap();
         temp_file.flush().unwrap();
 
-        let prov = LocalFileProvider::new(temp_file.path().to_path_buf(), None);
+        let prov = LocalFileProvider::new(temp_file.path().to_path_buf(), 0, None);
         let result = prov.get_custom_domains().await;
 
         assert!(result.is_err());
@@ -826,7 +860,7 @@ mod test {
 
     #[tokio::test]
     async fn test_local_file_provider_file_not_found() {
-        let prov = LocalFileProvider::new("/nonexistent/path/to/file.txt".into(), None);
+        let prov = LocalFileProvider::new("/nonexistent/path/to/file.txt".into(), 0, None);
         let result = prov.get_custom_domains().await;
 
         assert!(result.is_err());

--- a/ic-bn-lib/src/custom_domains/mod.rs
+++ b/ic-bn-lib/src/custom_domains/mod.rs
@@ -20,7 +20,7 @@ use fqdn::{FQDN, Fqdn};
 use http::header::AUTHORIZATION;
 use ic_bn_lib_common::{
     traits::{custom_domains::ProvidesCustomDomains, http::Client},
-    types::CustomDomain,
+    types::{CustomDomain, DomainFlags},
 };
 use reqwest::{Method, Request, Url};
 use serde::Deserialize;
@@ -76,6 +76,7 @@ async fn get_custom_domains_from_url(
     cli: &Arc<dyn Client>,
     url: &Url,
     timeout: Duration,
+    flags: Option<DomainFlags>,
 ) -> Result<Vec<CustomDomain>, Error> {
     let body = get_url_body(cli, url, timeout)
         .await
@@ -98,6 +99,7 @@ async fn get_custom_domains_from_url(
             name: k,
             canister_id: v,
             timestamp: 0,
+            flags,
         })
         .collect::<Vec<_>>())
 }
@@ -108,6 +110,7 @@ pub struct GenericProvider {
     http_client: Arc<dyn Client>,
     url: Url,
     timeout: Duration,
+    flags: Option<DomainFlags>,
 }
 
 impl Debug for GenericProvider {
@@ -119,7 +122,7 @@ impl Debug for GenericProvider {
 #[async_trait]
 impl ProvidesCustomDomains for GenericProvider {
     async fn get_custom_domains(&self) -> Result<Vec<CustomDomain>, Error> {
-        get_custom_domains_from_url(&self.http_client, &self.url, self.timeout).await
+        get_custom_domains_from_url(&self.http_client, &self.url, self.timeout, self.flags).await
     }
 }
 
@@ -137,6 +140,7 @@ pub struct GenericProviderTimestamped {
     http_client: Arc<dyn Client>,
     url: Url,
     timeout: Duration,
+    flags: Option<DomainFlags>,
     #[new(default)]
     timestamp: AtomicU64,
     #[new(default)]
@@ -181,9 +185,10 @@ impl ProvidesCustomDomains for GenericProviderTimestamped {
         };
 
         // Otherwise fetch a fresh version from the provided URL
-        let domains = get_custom_domains_from_url(&self.http_client, &domains_url, self.timeout)
-            .await
-            .context("unable to fetch custom domains")?;
+        let domains =
+            get_custom_domains_from_url(&self.http_client, &domains_url, self.timeout, self.flags)
+                .await
+                .context("unable to fetch custom domains")?;
 
         warn!("{self:?}: new timestamp, got {} domains", domains.len());
 
@@ -242,6 +247,7 @@ pub struct GenericProviderDiff {
     http_client: Arc<dyn Client>,
     url: Url,
     timeout: Duration,
+    flags: Option<DomainFlags>,
     #[new(default)]
     timestamp: AtomicU64,
     #[new(default)]
@@ -284,6 +290,7 @@ impl GenericProviderDiff {
                 name,
                 canister_id,
                 timestamp: 0,
+                flags: self.flags,
             })
             .collect()
     }
@@ -353,6 +360,7 @@ impl ProvidesCustomDomains for GenericProviderDiff {
 #[derive(new)]
 pub struct LocalFileProvider {
     file_path: PathBuf,
+    flags: Option<DomainFlags>,
 }
 
 impl Debug for LocalFileProvider {
@@ -397,6 +405,7 @@ impl ProvidesCustomDomains for LocalFileProvider {
                 name,
                 canister_id,
                 timestamp: 0,
+                flags: self.flags,
             });
         }
 
@@ -409,7 +418,7 @@ mod test {
     use ::http::Response as HttpResponse;
     use async_trait::async_trait;
     use fqdn::fqdn;
-    use ic_bn_lib_common::principal;
+    use ic_bn_lib_common::{principal, types::FLAG_PRERENDER};
     use itertools::Itertools;
     use serde_json::json;
 
@@ -553,7 +562,12 @@ mod test {
     #[tokio::test]
     async fn test_generic_provider_diff() {
         let cli = Arc::new(MockClientDiff);
-        let prov = GenericProviderDiff::new(cli, "http://foo".try_into().unwrap(), Duration::ZERO);
+        let prov = GenericProviderDiff::new(
+            cli,
+            "http://foo".try_into().unwrap(),
+            Duration::ZERO,
+            Some(DomainFlags::new([FLAG_PRERENDER])),
+        );
 
         // Check that 1st call provides the seed set
         let domains: Vec<CustomDomain> = prov
@@ -567,16 +581,13 @@ mod test {
         assert_eq!(
             domains,
             vec![
-                CustomDomain {
-                    name: fqdn!("foo.bar2"),
-                    canister_id: principal!("qoctq-giaaa-aaaaa-aaaea-cai"),
-                    timestamp: 0,
-                },
-                CustomDomain {
-                    name: fqdn!("2athis-domain-is-exactly-fifty-one-characters-l.com"),
-                    canister_id: principal!("aaaaa-aa"),
-                    timestamp: 0,
-                },
+                CustomDomain::new(fqdn!("foo.bar2"), principal!("qoctq-giaaa-aaaaa-aaaea-cai"))
+                    .set_flag(FLAG_PRERENDER),
+                CustomDomain::new(
+                    fqdn!("2athis-domain-is-exactly-fifty-one-characters-l.com"),
+                    principal!("aaaaa-aa"),
+                )
+                .set_flag(FLAG_PRERENDER)
             ]
         );
 
@@ -592,21 +603,12 @@ mod test {
         assert_eq!(
             domains,
             vec![
-                CustomDomain {
-                    name: fqdn!("foo.bar2"),
-                    canister_id: principal!("qoctq-giaaa-aaaaa-aaaea-cai"),
-                    timestamp: 0,
-                },
-                CustomDomain {
-                    name: fqdn!("foo.bar3"),
-                    canister_id: principal!("aaaaa-aa"),
-                    timestamp: 0,
-                },
-                CustomDomain {
-                    name: fqdn!("foo.bar4"),
-                    canister_id: principal!("qoctq-giaaa-aaaaa-aaaea-cai"),
-                    timestamp: 0,
-                },
+                CustomDomain::new(fqdn!("foo.bar2"), principal!("qoctq-giaaa-aaaaa-aaaea-cai"))
+                    .set_flag(FLAG_PRERENDER),
+                CustomDomain::new(fqdn!("foo.bar3"), principal!("aaaaa-aa"))
+                    .set_flag(FLAG_PRERENDER),
+                CustomDomain::new(fqdn!("foo.bar4"), principal!("qoctq-giaaa-aaaaa-aaaea-cai"))
+                    .set_flag(FLAG_PRERENDER),
             ]
         );
 
@@ -621,19 +623,22 @@ mod test {
 
         assert_eq!(
             domains,
-            vec![CustomDomain {
-                name: fqdn!("foo.bar5"),
-                canister_id: principal!("qoctq-giaaa-aaaaa-aaaea-cai"),
-                timestamp: 0,
-            },]
+            vec![
+                CustomDomain::new(fqdn!("foo.bar5"), principal!("qoctq-giaaa-aaaaa-aaaea-cai"))
+                    .set_flag(FLAG_PRERENDER)
+            ]
         );
     }
 
     #[tokio::test]
     async fn test_generic_provider_timestamped() {
         let cli = Arc::new(MockClientTimestamped(AtomicU64::new(0)));
-        let prov =
-            GenericProviderTimestamped::new(cli, "http://foo".try_into().unwrap(), Duration::ZERO);
+        let prov = GenericProviderTimestamped::new(
+            cli,
+            "http://foo".try_into().unwrap(),
+            Duration::ZERO,
+            Some(DomainFlags::new([FLAG_PRERENDER])),
+        );
 
         // Check that 1st call provides the 1st set of domains
         let domains: Vec<CustomDomain> = prov
@@ -647,16 +652,13 @@ mod test {
         assert_eq!(
             domains,
             vec![
-                CustomDomain {
-                    name: fqdn!("bar.foo"),
-                    canister_id: principal!("qoctq-giaaa-aaaaa-aaaea-cai"),
-                    timestamp: 0,
-                },
-                CustomDomain {
-                    name: fqdn!("2athis-domain-is-exactly-fifty-one-characters-l.com"),
-                    canister_id: principal!("aaaaa-aa"),
-                    timestamp: 0,
-                },
+                CustomDomain::new(fqdn!("bar.foo"), principal!("qoctq-giaaa-aaaaa-aaaea-cai"))
+                    .set_flag(FLAG_PRERENDER),
+                CustomDomain::new(
+                    fqdn!("2athis-domain-is-exactly-fifty-one-characters-l.com"),
+                    principal!("aaaaa-aa")
+                )
+                .set_flag(FLAG_PRERENDER),
             ]
         );
 
@@ -672,16 +674,13 @@ mod test {
         assert_eq!(
             domains,
             vec![
-                CustomDomain {
-                    name: fqdn!("bar.foo"),
-                    canister_id: principal!("qoctq-giaaa-aaaaa-aaaea-cai"),
-                    timestamp: 0,
-                },
-                CustomDomain {
-                    name: fqdn!("2athis-domain-is-exactly-fifty-one-characters-l.com"),
-                    canister_id: principal!("aaaaa-aa"),
-                    timestamp: 0,
-                },
+                CustomDomain::new(fqdn!("bar.foo"), principal!("qoctq-giaaa-aaaaa-aaaea-cai"))
+                    .set_flag(FLAG_PRERENDER),
+                CustomDomain::new(
+                    fqdn!("2athis-domain-is-exactly-fifty-one-characters-l.com"),
+                    principal!("aaaaa-aa")
+                )
+                .set_flag(FLAG_PRERENDER)
             ]
         );
 
@@ -697,16 +696,10 @@ mod test {
         assert_eq!(
             domains,
             vec![
-                CustomDomain {
-                    name: fqdn!("bar.foos"),
-                    canister_id: principal!("qoctq-giaaa-aaaaa-aaaea-cai"),
-                    timestamp: 0,
-                },
-                CustomDomain {
-                    name: fqdn!("foo.barr"),
-                    canister_id: principal!("aaaaa-aa"),
-                    timestamp: 0,
-                },
+                CustomDomain::new(fqdn!("bar.foos"), principal!("qoctq-giaaa-aaaaa-aaaea-cai"))
+                    .set_flag(FLAG_PRERENDER),
+                CustomDomain::new(fqdn!("foo.barr"), principal!("aaaaa-aa"))
+                    .set_flag(FLAG_PRERENDER)
             ]
         );
 
@@ -722,16 +715,10 @@ mod test {
         assert_eq!(
             domains,
             vec![
-                CustomDomain {
-                    name: fqdn!("bar.foos"),
-                    canister_id: principal!("qoctq-giaaa-aaaaa-aaaea-cai"),
-                    timestamp: 0,
-                },
-                CustomDomain {
-                    name: fqdn!("foo.barr"),
-                    canister_id: principal!("aaaaa-aa"),
-                    timestamp: 0,
-                },
+                CustomDomain::new(fqdn!("bar.foos"), principal!("qoctq-giaaa-aaaaa-aaaea-cai"))
+                    .set_flag(FLAG_PRERENDER),
+                CustomDomain::new(fqdn!("foo.barr"), principal!("aaaaa-aa"))
+                    .set_flag(FLAG_PRERENDER),
             ]
         );
     }
@@ -743,6 +730,7 @@ mod test {
             cli,
             "http://foo:bar@foo/beef".try_into().unwrap(),
             Duration::ZERO,
+            Some(DomainFlags::new([FLAG_PRERENDER])),
         );
 
         let domains: Vec<CustomDomain> = prov
@@ -756,25 +744,24 @@ mod test {
         assert_eq!(
             domains,
             vec![
-                CustomDomain {
-                    name: fqdn!("foo.bar"),
-                    canister_id: principal!("aaaaa-aa"),
-                    timestamp: 0,
-                },
-                CustomDomain {
-                    name: fqdn!("2athis-domain-is-exactly-fifty-one-characters-l.com"),
-                    canister_id: principal!("qoctq-giaaa-aaaaa-aaaea-cai"),
-                    timestamp: 0,
-                },
+                CustomDomain::new(fqdn!("foo.bar"), principal!("aaaaa-aa"))
+                    .set_flag(FLAG_PRERENDER),
+                CustomDomain::new(
+                    fqdn!("2athis-domain-is-exactly-fifty-one-characters-l.com"),
+                    principal!("qoctq-giaaa-aaaaa-aaaea-cai")
+                )
+                .set_flag(FLAG_PRERENDER),
             ]
         );
 
         let cli = Arc::new(MockClientBadDomain);
-        let prov = GenericProvider::new(cli, "http://foo".try_into().unwrap(), Duration::ZERO);
+        let prov =
+            GenericProvider::new(cli, "http://foo".try_into().unwrap(), Duration::ZERO, None);
         assert!(prov.get_custom_domains().await.is_err());
 
         let cli = Arc::new(MockClientBadCanister);
-        let prov = GenericProvider::new(cli, "http://foo".try_into().unwrap(), Duration::ZERO);
+        let prov =
+            GenericProvider::new(cli, "http://foo".try_into().unwrap(), Duration::ZERO, None);
         assert!(prov.get_custom_domains().await.is_err());
     }
 
@@ -793,7 +780,10 @@ mod test {
         .unwrap();
         temp_file.flush().unwrap();
 
-        let prov = LocalFileProvider::new(temp_file.path().to_path_buf());
+        let prov = LocalFileProvider::new(
+            temp_file.path().to_path_buf(),
+            Some(DomainFlags::new([FLAG_PRERENDER])),
+        );
         let mut domains: Vec<CustomDomain> = prov.get_custom_domains().await.unwrap();
         domains.sort_by(|a, b| a.name.cmp(&b.name));
 
@@ -801,21 +791,18 @@ mod test {
         assert_eq!(
             domains,
             vec![
-                CustomDomain {
-                    name: fqdn!("foo.bar"),
-                    canister_id: principal!("aaaaa-aa"),
-                    timestamp: 0,
-                },
-                CustomDomain {
-                    name: fqdn!("test.example.com"),
-                    canister_id: principal!("qoctq-giaaa-aaaaa-aaaea-cai"),
-                    timestamp: 0,
-                },
-                CustomDomain {
-                    name: fqdn!("2athis-domain-is-exactly-fifty-one-characters-l.com"),
-                    canister_id: principal!("ryjl3-tyaaa-aaaaa-aaaba-cai"),
-                    timestamp: 0,
-                },
+                CustomDomain::new(fqdn!("foo.bar"), principal!("aaaaa-aa"))
+                    .set_flag(FLAG_PRERENDER),
+                CustomDomain::new(
+                    fqdn!("test.example.com"),
+                    principal!("qoctq-giaaa-aaaaa-aaaea-cai"),
+                )
+                .set_flag(FLAG_PRERENDER),
+                CustomDomain::new(
+                    fqdn!("2athis-domain-is-exactly-fifty-one-characters-l.com"),
+                    principal!("ryjl3-tyaaa-aaaaa-aaaba-cai"),
+                )
+                .set_flag(FLAG_PRERENDER),
             ]
         );
     }
@@ -829,7 +816,7 @@ mod test {
         writeln!(temp_file, "foo.bar aaaaa-aa").unwrap();
         temp_file.flush().unwrap();
 
-        let prov = LocalFileProvider::new(temp_file.path().to_path_buf());
+        let prov = LocalFileProvider::new(temp_file.path().to_path_buf(), None);
         let result = prov.get_custom_domains().await;
 
         assert!(result.is_err());
@@ -839,7 +826,7 @@ mod test {
 
     #[tokio::test]
     async fn test_local_file_provider_file_not_found() {
-        let prov = LocalFileProvider::new("/nonexistent/path/to/file.txt".into());
+        let prov = LocalFileProvider::new("/nonexistent/path/to/file.txt".into(), None);
         let result = prov.get_custom_domains().await;
 
         assert!(result.is_err());

--- a/ic-bn-lib/src/custom_domains/mod.rs
+++ b/ic-bn-lib/src/custom_domains/mod.rs
@@ -6,7 +6,7 @@ use std::{
         Arc, Mutex,
         atomic::{AtomicU64, Ordering},
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use ahash::{HashMap, HashMapExt};
@@ -265,10 +265,13 @@ pub struct GenericProviderDiff {
     timeout: Duration,
     priority: u8,
     flags: Option<DomainFlags>,
+    full_refresh_interval: Duration,
     #[new(default)]
     timestamp: AtomicU64,
     #[new(default)]
     cache: Mutex<HashMap<FQDN, Principal>>,
+    #[new(default)]
+    last_full_refresh: Mutex<Option<Instant>>,
 }
 
 impl GenericProviderDiff {
@@ -291,6 +294,7 @@ impl GenericProviderDiff {
             .context("unable to get seed response")?;
 
         *self.cache.lock().unwrap() = resp.created;
+        *self.last_full_refresh.lock().unwrap() = Some(Instant::now());
         self.timestamp.store(resp.timestamp, Ordering::SeqCst);
 
         Ok(())
@@ -325,8 +329,14 @@ impl ProvidesCustomDomains for GenericProviderDiff {
     async fn get_custom_domains(&self) -> Result<Vec<CustomDomain>, Error> {
         let ts = self.timestamp.load(Ordering::SeqCst);
 
+        let time_to_refresh = self
+            .last_full_refresh
+            .lock()
+            .unwrap()
+            .is_none_or(|x| x.elapsed() > self.full_refresh_interval);
+
         // If the timestamp is zero - we need to seed our cache with full snapshot
-        if ts == 0 {
+        if ts == 0 || time_to_refresh {
             self.seed()
                 .await
                 .context("unable to download initial snapshot")?;
@@ -588,6 +598,7 @@ mod test {
             Duration::ZERO,
             0,
             Some(DomainFlags::new([FLAG_PRERENDER])),
+            Duration::from_secs(300),
         );
 
         // Check that 1st call provides the seed set

--- a/ic-bn-lib/src/http/cache.rs
+++ b/ic-bn-lib/src/http/cache.rs
@@ -1399,6 +1399,6 @@ mod tests {
             }
         }
 
-        assert!(refresh > 9);
+        assert!(refresh > 8);
     }
 }


### PR DESCRIPTION
Adds a concept of per-custom-domain bit flags & priority, currently with only one - `FLAG_PRERENDER` (plus the test one) to mark the domain for pre-rendering.

More PRs will follow for other crates.