### PR TITLE
Canister: move certificate data out of DomainEntry

### DIFF
--- a/custom-domains/api/src/lib.rs
+++ b/custom-domains/api/src/lib.rs
@@ -47,7 +47,7 @@ pub const DEFAULT_PAGE_LIMIT: u32 = 100;
 pub const MAX_PAGE_LIMIT: u32 = 400;
 
 // Interval for purging stale, unregistered domains
-pub const STALE_DOMAINS_CLEANUP_INTERVAL: Duration = Duration::from_secs(3 * 60 * 60);
+pub const STALE_DOMAINS_CLEANUP_INTERVAL: Duration = Duration::from_hours(3);
 
 pub type FetchTaskResult = Result<Option<ScheduledTask>, FetchTaskError>;
 pub type SubmitTaskResult = Result<(), SubmitTaskError>;

--- a/custom-domains/canister/Cargo.toml
+++ b/custom-domains/canister/Cargo.toml
@@ -26,3 +26,8 @@ strum = { workspace = true }
 
 [dev-dependencies]
 candid_parser = { workspace = true }
+
+[features]
+# Test-only endpoints for measuring instruction usage as a function of domain count.
+# Must never be enabled in a production build/deployment.
+bench = []

--- a/custom-domains/canister/src/bench.rs
+++ b/custom-domains/canister/src/bench.rs
@@ -1,0 +1,75 @@
+//! Test-only endpoints for measuring how many WASM instructions `CanisterState`'s
+//! full-scan methods consume as a function of the number of domains held.
+//!
+//! Gated behind the `bench` feature so none of this ships in a production build: it lets
+//! the caller inject arbitrary synthetic domain entries directly into stable storage,
+//! bypassing every validation `try_add_task` normally applies.
+
+use candid::CandidType;
+use ic_cdk::{api::instruction_counter, update};
+use serde::Deserialize;
+
+use crate::{
+    get_time_secs,
+    state::{DomainEntry, with_state, with_state_mut},
+};
+
+#[derive(CandidType, Deserialize, Clone, Copy, Debug)]
+pub enum BenchMethod {
+    HasNextTask,
+    FetchNextTask,
+    ComputeStats,
+    DomainsNearingExpiration,
+    CleanupStaleDomains,
+}
+
+/// Inserts `count` synthetic domain entries (keyed `bench-{start_index..start_index+count}.test`)
+/// with a certificate validity window far from expiration/renewal, so the seeded entries are
+/// inert: scanning them costs instructions, but doesn't trigger renewals or removals, keeping
+/// repeated measurements against the same seeded set stable and comparable.
+#[update]
+fn bench_seed_domains(count: u64, start_index: u64) {
+    let now = get_time_secs();
+
+    with_state_mut(|state| {
+        for i in 0..count {
+            let mut entry = DomainEntry::new(None, now);
+            entry.not_before = Some(now.saturating_sub(1_000_000));
+            entry.not_after = Some(now + 1_000_000_000);
+            state
+                .domains
+                .insert(format!("bench-{}.test", start_index + i), entry);
+        }
+    });
+}
+
+#[update]
+fn bench_domain_count() -> u64 {
+    with_state(|state| state.domains.len())
+}
+
+/// Runs `method` once against the current state and returns the number of WASM instructions
+/// it consumed (via `ic_cdk::api::instruction_counter`), isolated from the seeding cost above.
+#[update]
+fn bench_measure(method: BenchMethod) -> u64 {
+    let now = get_time_secs();
+    let start = instruction_counter();
+
+    with_state_mut(|state| match method {
+        BenchMethod::HasNextTask => {
+            let _ = state.has_next_task(now);
+        }
+        BenchMethod::FetchNextTask => {
+            let _ = state.fetch_next_task(now);
+        }
+        BenchMethod::ComputeStats => {
+            let _ = state.compute_stats(now);
+        }
+        BenchMethod::DomainsNearingExpiration => {
+            let _ = state.domains_nearing_expiration(now);
+        }
+        BenchMethod::CleanupStaleDomains => state.cleanup_stale_domains(now),
+    });
+
+    instruction_counter() - start
+}

--- a/custom-domains/canister/src/lib.rs
+++ b/custom-domains/canister/src/lib.rs
@@ -19,6 +19,8 @@ use crate::{
     storage::AUTHORIZED_PRINCIPAL,
 };
 
+#[cfg(feature = "bench")]
+mod bench;
 pub mod metrics;
 pub mod state;
 pub mod storage;
@@ -141,7 +143,9 @@ fn http_request(request: HttpRequest) -> HttpResponse {
     }
 }
 
-#[cfg(test)]
+// The `bench` feature adds extra test-only endpoints that intentionally aren't part of
+// the public candid interface, so this check doesn't apply to that build configuration.
+#[cfg(all(test, not(feature = "bench")))]
 mod tests {
     use std::{env, fs::read_to_string, path::PathBuf};
 

--- a/custom-domains/canister/src/lib.rs
+++ b/custom-domains/canister/src/lib.rs
@@ -12,7 +12,6 @@ use ic_custom_domains_canister_api::{
     SubmitTaskResult, TaskResult, TryAddTaskError, TryAddTaskResult,
 };
 use ic_http_types::{HttpRequest, HttpResponse, HttpResponseBuilder};
-use ic_stable_structures::memory_manager::MemoryId;
 
 use crate::{
     metrics::{METRICS, export_metrics_as_http_response},
@@ -24,7 +23,7 @@ pub mod metrics;
 pub mod state;
 pub mod storage;
 
-// Inspect ingress messages in the pre-consensus phase and reject early, if the caller is unauthorized
+/// Inspect ingress messages in the pre-consensus phase and reject early, if the caller is unauthorized
 #[inspect_message]
 fn inspect_message() {
     if let Some(authorized_principal) = AUTHORIZED_PRINCIPAL.with(|p| *p.borrow())
@@ -66,16 +65,9 @@ fn init(init_arg: InitArg) {
     });
 }
 
-// Run every time a canister is upgraded
+/// Run every time a canister is upgraded
 #[post_upgrade]
 fn post_upgrade(init_arg: InitArg) {
-    // One-time move of enc_cert/enc_priv_key out of DomainEntry into the certificates map;
-    // a no-op after the first run (see `migrate_certificates_out_of_domains`).
-    with_state_mut(|state| {
-        let domains_memory = storage::MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(0)));
-        state.migrate_certificates_out_of_domains(domains_memory);
-    });
-
     // Run the same initialization logic
     init(init_arg);
 }

--- a/custom-domains/canister/src/lib.rs
+++ b/custom-domains/canister/src/lib.rs
@@ -21,9 +21,9 @@ use crate::{
 
 #[cfg(feature = "bench")]
 mod bench;
-pub mod metrics;
-pub mod state;
-pub mod storage;
+mod metrics;
+mod state;
+mod storage;
 
 /// Inspect ingress messages in the pre-consensus phase and reject early, if the caller is unauthorized
 #[inspect_message]

--- a/custom-domains/canister/src/lib.rs
+++ b/custom-domains/canister/src/lib.rs
@@ -12,6 +12,7 @@ use ic_custom_domains_canister_api::{
     SubmitTaskResult, TaskResult, TryAddTaskError, TryAddTaskResult,
 };
 use ic_http_types::{HttpRequest, HttpResponse, HttpResponseBuilder};
+use ic_stable_structures::memory_manager::MemoryId;
 
 use crate::{
     metrics::{METRICS, export_metrics_as_http_response},
@@ -68,6 +69,13 @@ fn init(init_arg: InitArg) {
 // Run every time a canister is upgraded
 #[post_upgrade]
 fn post_upgrade(init_arg: InitArg) {
+    // One-time move of enc_cert/enc_priv_key out of DomainEntry into the certificates map;
+    // a no-op after the first run (see `migrate_certificates_out_of_domains`).
+    with_state_mut(|state| {
+        let domains_memory = storage::MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(0)));
+        state.migrate_certificates_out_of_domains(domains_memory);
+    });
+
     // Run the same initialization logic
     init(init_arg);
 }

--- a/custom-domains/canister/src/state.rs
+++ b/custom-domains/canister/src/state.rs
@@ -1,3 +1,6 @@
+use std::hash::Hash;
+use std::{borrow::Cow, collections::HashMap, ops::Bound as RangeBound};
+
 use candid::Principal;
 use ic_custom_domains_canister_api::{
     CERT_EXPIRATION_ALERT_THRESHOLD, CERTIFICATE_VALIDITY_FRACTION, CertificatesPage,
@@ -17,13 +20,9 @@ use ic_stable_structures::{
 };
 use serde::{Deserialize, Serialize};
 use serde_cbor::{from_slice, to_vec};
-use std::hash::Hash;
-use std::{borrow::Cow, collections::HashMap, ops::Bound as RangeBound};
 use strum::{EnumIter, IntoEnumIterator, IntoStaticStr};
 
-use crate::storage::MAX_STORED_DOMAINS;
 use crate::{
-    get_time_secs,
     metrics::{
         FAILURE_STATUS, FETCH_NEXT_TASK_FUNC, METRICS, SUBMIT_TASK_RESULT_FUNC, SUCCESS_STATUS,
         TRY_ADD_TASK_FUNC,
@@ -54,10 +53,6 @@ pub struct DomainEntry {
     pub taken_at: Option<UtcTimestamp>,
     // Timestamp when the current task was created
     pub task_created_at: Option<UtcTimestamp>,
-    // PEM-encoded certificate data (encrypted)
-    pub enc_cert: Option<Vec<u8>>,
-    // PEM-encoded private key data (encrypted)
-    pub enc_priv_key: Option<Vec<u8>>,
     // Certificate validity period start (as UNIX timestamp)
     pub not_before: Option<UtcTimestamp>,
     // Certificate validity period end (as UNIX timestamp)
@@ -67,6 +62,72 @@ pub struct DomainEntry {
     // after upgrade (they predate this field and default to `false`).
     #[serde(default)]
     pub wildcard: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CertificateEntry {
+    // PEM-encoded certificate data (encrypted)
+    pub enc_cert: Vec<u8>,
+    // PEM-encoded private key data (encrypted)
+    pub enc_priv_key: Vec<u8>,
+}
+
+impl Storable for CertificateEntry {
+    const BOUND: Bound = Bound::Unbounded;
+
+    fn to_bytes(&self) -> std::borrow::Cow<'_, [u8]> {
+        Cow::Owned(to_vec(&self).expect("CertificateEntry serialization failed"))
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        to_vec(&self).expect("CertificateEntry serialization failed")
+    }
+
+    fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {
+        from_slice(&bytes).expect("CertificateEntry deserialization failed")
+    }
+}
+
+/// Mirrors `DomainEntry`'s on-disk shape from before `enc_cert`/`enc_priv_key` were split
+/// out into `CertificateEntry`. Used only to recover those fields from stable memory
+/// during the one-time post-upgrade migration; `#[serde(default)]` on both fields lets it
+/// also parse already-migrated (trimmed) bytes without error, so re-running the migration
+/// stays safe even though it is guarded to run only once.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DomainEntryV1 {
+    task: Option<TaskKind>,
+    last_fail_time: Option<UtcTimestamp>,
+    last_failure_reason: Option<TaskFailReason>,
+    failures_count: u32,
+    rate_limit_failures_count: u32,
+    canister_id: Option<Principal>,
+    created_at: UtcTimestamp,
+    taken_at: Option<UtcTimestamp>,
+    task_created_at: Option<UtcTimestamp>,
+    #[serde(default)]
+    enc_cert: Option<Vec<u8>>,
+    #[serde(default)]
+    enc_priv_key: Option<Vec<u8>>,
+    not_before: Option<UtcTimestamp>,
+    not_after: Option<UtcTimestamp>,
+    #[serde(default)]
+    wildcard: bool,
+}
+
+impl Storable for DomainEntryV1 {
+    const BOUND: Bound = Bound::Unbounded;
+
+    fn to_bytes(&self) -> std::borrow::Cow<'_, [u8]> {
+        Cow::Owned(to_vec(&self).expect("DomainEntryV1 serialization failed"))
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        to_vec(&self).expect("DomainEntryV1 serialization failed")
+    }
+
+    fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {
+        from_slice(&bytes).expect("DomainEntryV1 deserialization failed")
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, IntoStaticStr)]
@@ -128,10 +189,14 @@ impl DomainEntry {
     }
 
     pub fn registration_status(&self, now: UtcTimestamp) -> RegistrationStatus {
-        if let (Some(_cert), Some(not_after)) = (&self.enc_cert, self.not_after) {
+        // `not_after` is only ever set together with the certificate (see
+        // `submit_task_result`), so its presence is a reliable, cheap proxy for "certificate
+        // issued" that avoids a `certificates` map lookup on this hot, per-entry path.
+        if let Some(not_after) = self.not_after {
             if now < not_after {
                 return RegistrationStatus::Registered;
             }
+
             RegistrationStatus::Expired
         } else if self.task == Some(TaskKind::Issue) {
             RegistrationStatus::Registering
@@ -173,6 +238,8 @@ impl DomainEntry {
 }
 
 impl Storable for DomainEntry {
+    const BOUND: Bound = Bound::Unbounded;
+
     fn to_bytes(&self) -> std::borrow::Cow<'_, [u8]> {
         Cow::Owned(to_vec(&self).expect("DomainEntry serialization failed"))
     }
@@ -184,17 +251,91 @@ impl Storable for DomainEntry {
     fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {
         from_slice(&bytes).expect("DomainEntry deserialization failed")
     }
-
-    const BOUND: Bound = Bound::Unbounded;
 }
 
 pub struct CanisterState {
     pub domains: StableBTreeMap<String, DomainEntry, VirtualMemory<DefaultMemoryImpl>>,
     pub last_change: StableCell<UtcTimestamp, VirtualMemory<DefaultMemoryImpl>>,
+    pub certificates: StableBTreeMap<String, CertificateEntry, VirtualMemory<DefaultMemoryImpl>>,
     pub max_domains: u64,
+    /// Guards `migrate_certificates_out_of_domains`, so the one-time rewrite of every
+    /// domain entry only ever runs on the first post-upgrade after this migration shipped.
+    pub certificates_migrated: StableCell<bool, VirtualMemory<DefaultMemoryImpl>>,
 }
 
 impl CanisterState {
+    /// One-time migration: moves `enc_cert`/`enc_priv_key` out of each `DomainEntry` and
+    /// into the `certificates` map, then rewrites the (now smaller) entry back into
+    /// `domains`. Before this ran, every full scan over `domains` (stats, cleanup, task
+    /// scheduling) had to decode the certificate/key bytes of every entry just to skip
+    /// past them, which is what made those scans expensive.
+    ///
+    /// Safe to call on every post_upgrade: guarded by `certificates_migrated` so it's a
+    /// no-op after the first run, and reads legacy bytes through `DomainEntryV1`, whose
+    /// `#[serde(default)]` cert fields also parse already-migrated entries without error.
+    ///
+    /// Reads proceed key-by-key via point lookups (`get`), never a live iterator held
+    /// across a mutation of `domains`/`certificates` on the same underlying stable memory.
+    /// `domains_memory` must be a *second* handle onto the same memory region backing
+    /// `self.domains` (e.g. another `MEMORY_MANAGER.get(MemoryId::new(0))` call) — taken as
+    /// a parameter, rather than reached for internally, so this stays testable against
+    /// any `CanisterState`/`MemoryManager` pairing instead of only the real canister's.
+    pub fn migrate_certificates_out_of_domains(
+        &mut self,
+        domains_memory: VirtualMemory<DefaultMemoryImpl>,
+    ) {
+        if *self.certificates_migrated.get() {
+            return;
+        }
+
+        let legacy_domains: StableBTreeMap<
+            String,
+            DomainEntryV1,
+            VirtualMemory<DefaultMemoryImpl>,
+        > = StableBTreeMap::init(domains_memory);
+
+        let domain_keys: Vec<String> = self.domains.keys().collect();
+
+        for domain in domain_keys {
+            let Some(legacy_entry) = legacy_domains.get(&domain) else {
+                continue;
+            };
+
+            if let (Some(enc_cert), Some(enc_priv_key)) = (
+                legacy_entry.enc_cert.clone(),
+                legacy_entry.enc_priv_key.clone(),
+            ) {
+                self.certificates.insert(
+                    domain.clone(),
+                    CertificateEntry {
+                        enc_cert,
+                        enc_priv_key,
+                    },
+                );
+            }
+
+            self.domains.insert(
+                domain,
+                DomainEntry {
+                    task: legacy_entry.task,
+                    last_fail_time: legacy_entry.last_fail_time,
+                    last_failure_reason: legacy_entry.last_failure_reason,
+                    failures_count: legacy_entry.failures_count,
+                    rate_limit_failures_count: legacy_entry.rate_limit_failures_count,
+                    canister_id: legacy_entry.canister_id,
+                    created_at: legacy_entry.created_at,
+                    taken_at: legacy_entry.taken_at,
+                    task_created_at: legacy_entry.task_created_at,
+                    not_before: legacy_entry.not_before,
+                    not_after: legacy_entry.not_after,
+                    wildcard: legacy_entry.wildcard,
+                },
+            );
+        }
+
+        self.certificates_migrated.set(true);
+    }
+
     // Processes all domains and returns true if next task exists.
     pub fn has_next_task(&self, now: UtcTimestamp) -> HasNextTaskResult {
         let has_task = self
@@ -268,11 +409,13 @@ impl CanisterState {
                 domain_entry.taken_at = Some(now);
                 self.domains.insert(domain.clone(), domain_entry.clone());
 
+                let enc_cert = self.certificates.get(&domain).map(|cert| cert.enc_cert);
+
                 Ok(Some(ScheduledTask::new(
                     domain_entry.task.unwrap(),
                     domain,
                     now,
-                    domain_entry.enc_cert,
+                    enc_cert,
                     Some(domain_entry.wildcard),
                 )))
             }
@@ -357,7 +500,8 @@ impl CanisterState {
             None => return Ok(None),
         };
 
-        Ok(Some(entry.into()))
+        let cert = self.certificates.get(&domain);
+        Ok(Some(domain_entry_to_api(entry, cert)))
     }
 
     // Removes unregistered domains that have been in the system for too long
@@ -370,7 +514,9 @@ impl CanisterState {
 
             // Remove domain if it stayed unregistered for more than UNREGISTERED_DOMAIN_EXPIRATION_TIME
             // This covers new registrations that fail to be completed
-            let unregistered_too_long = domain_entry.enc_cert.is_none()
+            // (`not_after` is only ever set alongside the certificate, so its absence
+            // reliably means no certificate has been issued yet)
+            let unregistered_too_long = domain_entry.not_after.is_none()
                 && domain_entry.task.is_none()
                 && now
                     >= domain_entry
@@ -388,9 +534,11 @@ impl CanisterState {
             }
         }
 
-        // Remove expired/unregistered domains
+        // Remove expired/unregistered domains, along with any associated certificate
+        // data so it doesn't linger orphaned in the certificates map.
         for domain in domains_to_remove {
             self.domains.remove(&domain);
+            self.certificates.remove(&domain);
         }
 
         METRICS.with(|cell| {
@@ -453,15 +601,17 @@ impl CanisterState {
 
                 // Prevent explicit certificate re-issuance (if the domain is not near expiration)
                 // Note: to reissue certificate, submit `Renew` task instead
+                // (`not_after` is only ever set alongside the certificate, so it's a
+                // reliable, cheap proxy for "certificate issued" here)
                 if task.kind == TaskKind::Issue
-                    && entry.enc_cert.is_some()
+                    && entry.not_after.is_some()
                     && !entry.is_nearing_expiration(now)
                 {
                     return Err(TryAddTaskError::CertificateAlreadyIssued(domain));
                 }
 
                 // Require an existing certificate for `Update` task
-                if task.kind == TaskKind::Update && entry.enc_cert.is_none() {
+                if task.kind == TaskKind::Update && entry.not_after.is_none() {
                     return Err(TryAddTaskError::MissingCertificateForUpdate(domain));
                 }
 
@@ -564,13 +714,19 @@ impl CanisterState {
                 match output {
                     TaskOutput::Issue(output) => {
                         entry.canister_id = Some(output.canister_id);
-                        entry.enc_cert = Some(output.enc_cert);
-                        entry.enc_priv_key = Some(output.enc_priv_key);
                         entry.not_before = Some(output.not_before);
                         entry.not_after = Some(output.not_after);
+                        self.certificates.insert(
+                            domain.clone(),
+                            CertificateEntry {
+                                enc_cert: output.enc_cert,
+                                enc_priv_key: output.enc_priv_key,
+                            },
+                        );
                     }
                     TaskOutput::Delete => {
                         self.domains.remove(&domain);
+                        self.certificates.remove(&domain);
                         return Ok(());
                     }
                     TaskOutput::Update(canister_id) => {
@@ -636,22 +792,27 @@ impl CanisterState {
             let domain = entry.key();
             let domain_entry = entry.value();
 
-            // Only include domains with issued certificates and existing canister_id
-            if let (Some(cert), Some(private_key), Some(canister_id)) = (
-                &domain_entry.enc_cert,
-                &domain_entry.enc_priv_key,
-                &domain_entry.canister_id,
-            ) {
+            // Only include domains with an issued certificate and existing canister_id.
+            // `not_after` is only ever set alongside the certificate, so it's a reliable,
+            // cheap proxy for "certificate issued" that avoids a `certificates` map lookup
+            // for every entry scanned (as opposed to only the ones actually returned below).
+            if domain_entry.not_after.is_some()
+                && let Some(canister_id) = &domain_entry.canister_id
+            {
                 if count >= limit {
                     next_key = Some(domain.clone());
                     break;
                 }
 
+                let Some(cert_entry) = self.certificates.get(domain) else {
+                    continue;
+                };
+
                 registered_domains.push(RegisteredDomain {
                     domain: domain.clone(),
                     canister_id: *canister_id,
-                    enc_cert: cert.clone(),
-                    enc_priv_key: private_key.clone(),
+                    enc_cert: cert_entry.enc_cert,
+                    enc_priv_key: cert_entry.enc_priv_key,
                 });
 
                 count += 1;
@@ -659,7 +820,6 @@ impl CanisterState {
         }
 
         let page = CertificatesPage::new(registered_domains, next_key);
-
         Ok(page)
     }
 
@@ -710,63 +870,6 @@ impl CanisterState {
     }
 }
 
-impl CanisterState {
-    /// Creates a new CanisterState with optionally pre-populated domains for testing
-    pub fn new_with_sample_domains(num_domains: usize, cert_size_bytes: usize) -> Self {
-        use ic_stable_structures::memory_manager::{MemoryId, MemoryManager};
-
-        let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
-        let domains_memory = memory_manager.get(MemoryId::new(0));
-        let last_change_memory = memory_manager.get(MemoryId::new(1));
-
-        let domains = StableBTreeMap::init(domains_memory);
-        let last_change = StableCell::init(last_change_memory, 1);
-
-        let mut state = Self {
-            domains,
-            last_change,
-            max_domains: MAX_STORED_DOMAINS,
-        };
-
-        // Some sample canister IDs
-        let sample_canister_ids = [
-            Principal::from_text("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap(),
-            Principal::from_text("rrkah-fqaaa-aaaaa-aaaaq-cai").unwrap(),
-            Principal::from_text("rno2w-sqaaa-aaaaa-aaacq-cai").unwrap(),
-            Principal::from_text("renrk-eyaaa-aaaaa-aaada-cai").unwrap(),
-            Principal::from_text("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap(),
-        ];
-
-        for i in 0..num_domains {
-            let domain = format!("domain_{i}.example.com");
-            let canister_id = sample_canister_ids[i % sample_canister_ids.len()];
-
-            let mut domain_entry = DomainEntry::new(None, i as u64);
-            domain_entry.canister_id = Some(canister_id);
-
-            // Generate certificate data of specified size
-            let cert_data = {
-                let base_cert = format!("-----BEGIN CERTIFICATE-----\ncert_data_{}\n", i + 1);
-                let padding = "X".repeat(cert_size_bytes);
-                format!("{base_cert}{padding}-----END CERTIFICATE-----")
-            };
-
-            // Generate private key data
-            let key_data = format!("key_data_{}", i + 1);
-
-            let now = get_time_secs();
-            domain_entry.enc_cert = Some(cert_data.into_bytes());
-            domain_entry.enc_priv_key = Some(key_data.into_bytes());
-            domain_entry.not_before = Some(now);
-            domain_entry.not_after = Some(now + 30 * 24 * 60 * 60);
-
-            state.domains.insert(domain, domain_entry);
-        }
-
-        state
-    }
-}
-
 /// Determines the next pending task for a domain entry based on current state and time.
 fn next_pending_task(entry: &DomainEntry, now: UtcTimestamp) -> Option<TaskKind> {
     // Normal existing tasks are always prioritized over scheduling renewals
@@ -784,12 +887,9 @@ fn next_pending_task(entry: &DomainEntry, now: UtcTimestamp) -> Option<TaskKind>
     // `failures_count` hits `MAX_TASK_FAILURES`, and without this check we'd
     // recreate a fresh `Renew` task here on the very next call, ignoring both
     // `MIN_TASK_RETRY_DELAY` and the failure cap that was just enforced.
-    if let (None, Some(_cert), Some(not_before), Some(not_after)) = (
-        entry.task,
-        entry.enc_cert.as_ref(),
-        entry.not_before,
-        entry.not_after,
-    ) && renewal_needed(not_before, not_after, now)
+    if let (None, Some(not_before), Some(not_after)) =
+        (entry.task, entry.not_before, entry.not_after)
+        && renewal_needed(not_before, not_after, now)
         && retry_allowed(entry, now)
     {
         return Some(TaskKind::Renew);
@@ -876,29 +976,32 @@ pub fn export_expiring_domains_as_http_response(now: UtcTimestamp) -> HttpRespon
         .build()
 }
 
-impl From<DomainEntry> for DomainEntryApi {
-    fn from(entry: DomainEntry) -> Self {
-        Self {
-            task: entry.task,
-            last_fail_time: entry.last_fail_time,
-            last_failure_reason: entry.last_failure_reason.clone(),
-            failures_count: entry.failures_count,
-            rate_limit_failures_count: entry.rate_limit_failures_count,
-            canister_id: entry.canister_id,
-            created_at: entry.created_at,
-            taken_at: entry.taken_at,
-            task_created_at: entry.task_created_at,
-            enc_cert: entry.enc_cert.clone(),
-            enc_priv_key: entry.enc_priv_key.clone(),
-            not_before: entry.not_before,
-            not_after: entry.not_after,
-            wildcard: Some(entry.wildcard),
-        }
+/// Builds the public (candid) `DomainEntry` from the internal, cert-less entry plus its
+/// certificate data (looked up separately, since `enc_cert`/`enc_priv_key` no longer live
+/// on the internal `DomainEntry`).
+fn domain_entry_to_api(entry: DomainEntry, cert: Option<CertificateEntry>) -> DomainEntryApi {
+    DomainEntryApi {
+        task: entry.task,
+        last_fail_time: entry.last_fail_time,
+        last_failure_reason: entry.last_failure_reason.clone(),
+        failures_count: entry.failures_count,
+        rate_limit_failures_count: entry.rate_limit_failures_count,
+        canister_id: entry.canister_id,
+        created_at: entry.created_at,
+        taken_at: entry.taken_at,
+        task_created_at: entry.task_created_at,
+        enc_cert: cert.as_ref().map(|c| c.enc_cert.clone()),
+        enc_priv_key: cert.map(|c| c.enc_priv_key),
+        not_before: entry.not_before,
+        not_after: entry.not_after,
+        wildcard: Some(entry.wildcard),
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::storage::MAX_STORED_DOMAINS;
+
     use super::*;
     use candid::Principal;
     use ic_custom_domains_canister_api::{IssueCertificateOutput, TaskKind as TaskKindApi};
@@ -925,6 +1028,10 @@ mod tests {
 
     /// A `DomainEntry` persisted before the `wildcard` field existed must still deserialize
     /// after upgrade, defaulting `wildcard` to `false` (guards the `#[serde(default)]`).
+    /// It also carries `enc_cert`/`enc_priv_key`, which `DomainEntry` no longer declares
+    /// since the certificate split: those extra CBOR map keys must be silently ignored
+    /// rather than causing a deserialization error, since that's exactly the property
+    /// `migrate_certificates_out_of_domains` relies on being safe.
     #[test]
     fn test_domain_entry_deserializes_legacy_bytes_without_wildcard() {
         let legacy = LegacyDomainEntry {
@@ -957,21 +1064,120 @@ mod tests {
         assert_eq!(entry.task, Some(TaskKind::Issue));
         assert_eq!(entry.failures_count, 3);
         assert_eq!(entry.created_at, 1000);
-        assert_eq!(entry.enc_cert, Some(b"cert".to_vec()));
+    }
+
+    /// `migrate_certificates_out_of_domains` must move `enc_cert`/`enc_priv_key` out of
+    /// stable-storage bytes written by a pre-migration canister and into the certificates
+    /// map, then rewrite the domain entry without them.
+    #[test]
+    fn test_migrate_certificates_out_of_domains() {
+        // Built by hand (rather than via `create_test_empty_state`) so the test keeps its
+        // own `MemoryManager` around: a second `.get(MemoryId::new(0))` call on that same
+        // manager is what gives `legacy_domains` a view onto the exact bytes `state.domains`
+        // is backed by.
+        let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
+
+        // Write raw legacy-shaped bytes directly into the domains memory region, exactly as
+        // a pre-migration canister would have, bypassing the (already trimmed) `DomainEntry`
+        // Storable impl. This must happen *before* `state.domains` below is constructed:
+        // `StableBTreeMap::init` caches the tree's root address/length in Rust-level fields
+        // at construction time (mirroring `BTreeHeader`), so it only sees data already on
+        // disk at that point — exactly like a real upgrade, where the previous canister run's
+        // data is on disk before the new run's `STATE` is lazily initialized.
+        let mut legacy_domains: StableBTreeMap<
+            String,
+            DomainEntryV1,
+            VirtualMemory<DefaultMemoryImpl>,
+        > = StableBTreeMap::init(memory_manager.get(MemoryId::new(0)));
+        legacy_domains.insert(
+            "example.com".to_string(),
+            DomainEntryV1 {
+                task: None,
+                last_fail_time: None,
+                last_failure_reason: None,
+                failures_count: 0,
+                rate_limit_failures_count: 0,
+                canister_id: Some(Principal::from_text("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap()),
+                created_at: 1000,
+                taken_at: None,
+                task_created_at: None,
+                enc_cert: Some(b"cert_data".to_vec()),
+                enc_priv_key: Some(b"key_data".to_vec()),
+                not_before: Some(1500),
+                not_after: Some(2500),
+                wildcard: true,
+            },
+        );
+        // A domain that never had a certificate issued must not gain a spurious entry.
+        legacy_domains.insert(
+            "pending.net".to_string(),
+            DomainEntryV1 {
+                task: Some(TaskKind::Issue),
+                last_fail_time: None,
+                last_failure_reason: None,
+                failures_count: 0,
+                rate_limit_failures_count: 0,
+                canister_id: None,
+                created_at: 1200,
+                taken_at: None,
+                task_created_at: None,
+                enc_cert: None,
+                enc_priv_key: None,
+                not_before: None,
+                not_after: None,
+                wildcard: false,
+            },
+        );
+
+        let mut state = CanisterState {
+            domains: StableBTreeMap::init(memory_manager.get(MemoryId::new(0))),
+            last_change: StableCell::init(memory_manager.get(MemoryId::new(1)), 0),
+            certificates: StableBTreeMap::init(memory_manager.get(MemoryId::new(2))),
+            max_domains: MAX_STORED_DOMAINS,
+            certificates_migrated: StableCell::init(memory_manager.get(MemoryId::new(3)), false),
+        };
+
+        state.migrate_certificates_out_of_domains(memory_manager.get(MemoryId::new(0)));
+
+        let cert = state
+            .certificates
+            .get(&"example.com".to_string())
+            .expect("certificate should have been migrated");
+        assert_eq!(cert.enc_cert, b"cert_data");
+        assert_eq!(cert.enc_priv_key, b"key_data");
+        assert!(state.certificates.get(&"pending.net".to_string()).is_none());
+
+        let entry = state.domains.get(&"example.com".to_string()).unwrap();
+        assert_eq!(entry.not_before, Some(1500));
+        assert_eq!(entry.not_after, Some(2500));
+        assert!(entry.wildcard);
+
+        assert!(*state.certificates_migrated.get());
+
+        // Re-running must be a no-op: it's guarded by `certificates_migrated`, so a second
+        // call must not resurrect anything even if the raw legacy bytes were still there.
+        state.migrate_certificates_out_of_domains(memory_manager.get(MemoryId::new(0)));
+        assert_eq!(state.certificates.len(), 1);
     }
 
     fn create_test_empty_state() -> CanisterState {
         let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
         let domains_memory = memory_manager.get(MemoryId::new(0));
         let last_change_memory = memory_manager.get(MemoryId::new(1));
+        let certs_memory = memory_manager.get(MemoryId::new(2));
+        let migrated_memory = memory_manager.get(MemoryId::new(3));
 
         let domains = StableBTreeMap::init(domains_memory);
         let last_change = StableCell::init(last_change_memory, 0);
+        let certificates = StableBTreeMap::init(certs_memory);
+        let certificates_migrated = StableCell::init(migrated_memory, false);
 
         CanisterState {
             domains,
             last_change,
+            certificates,
             max_domains: MAX_STORED_DOMAINS,
+            certificates_migrated,
         }
     }
 
@@ -980,14 +1186,20 @@ mod tests {
         let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
         let domains_memory = memory_manager.get(MemoryId::new(0));
         let last_change_memory = memory_manager.get(MemoryId::new(1));
+        let certs_memory = memory_manager.get(MemoryId::new(2));
+        let migrated_memory = memory_manager.get(MemoryId::new(3));
 
         let domains = StableBTreeMap::init(domains_memory);
         let last_change = StableCell::init(last_change_memory, 0);
+        let certificates = StableBTreeMap::init(certs_memory);
+        let certificates_migrated = StableCell::init(migrated_memory, false);
 
         let mut state = CanisterState {
             domains,
             last_change,
+            certificates,
             max_domains: MAX_STORED_DOMAINS,
+            certificates_migrated,
         };
 
         let canister_id_1 = Principal::from_text("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap();
@@ -997,20 +1209,30 @@ mod tests {
         // Domain with certificate
         let mut domain1 = DomainEntry::new(None, 1000);
         domain1.canister_id = Some(canister_id_1);
-        domain1.enc_cert = Some(b"cert1_data".to_vec());
-        domain1.enc_priv_key = Some(b"key1_data".to_vec());
         domain1.not_before = Some(1500);
         domain1.not_after = Some(2500);
         state.domains.insert("example.com".to_string(), domain1);
+        state.certificates.insert(
+            "example.com".to_string(),
+            CertificateEntry {
+                enc_cert: b"cert1_data".to_vec(),
+                enc_priv_key: b"key1_data".to_vec(),
+            },
+        );
 
         // Another domain with certificate
         let mut domain2 = DomainEntry::new(None, 1100);
         domain2.canister_id = Some(canister_id_2);
-        domain2.enc_cert = Some(b"cert2_data".to_vec());
-        domain2.enc_priv_key = Some(b"key2_data".to_vec());
         domain2.not_before = Some(1600);
         domain2.not_after = Some(2600);
         state.domains.insert("test.org".to_string(), domain2);
+        state.certificates.insert(
+            "test.org".to_string(),
+            CertificateEntry {
+                enc_cert: b"cert2_data".to_vec(),
+                enc_priv_key: b"key2_data".to_vec(),
+            },
+        );
 
         // Domain without certificate (should be excluded)
         let domain3 = DomainEntry::new(Some(TaskKind::Issue), 1200);
@@ -1019,26 +1241,35 @@ mod tests {
         // Another domain with certificate
         let mut domain4 = DomainEntry::new(None, 1300);
         domain4.canister_id = Some(canister_id_3);
-        domain4.enc_cert = Some(b"cert3_data".to_vec());
-        domain4.enc_priv_key = Some(b"key3_data".to_vec());
         domain4.not_before = Some(1700);
         domain4.not_after = Some(2700);
         state.domains.insert("website.io".to_string(), domain4);
+        state.certificates.insert(
+            "website.io".to_string(),
+            CertificateEntry {
+                enc_cert: b"cert3_data".to_vec(),
+                enc_priv_key: b"key3_data".to_vec(),
+            },
+        );
 
         // Domain without certificate (should be excluded)
         let mut domain5 = DomainEntry::new(None, 1400);
         domain5.canister_id = Some(canister_id_1);
-        domain5.enc_cert = None;
         state.domains.insert("incomplete.dev".to_string(), domain5);
 
         // Another domain with certificate
         let mut domain6 = DomainEntry::new(None, 1300);
         domain6.canister_id = Some(canister_id_2);
-        domain6.enc_cert = Some(b"cert6_data".to_vec());
-        domain6.enc_priv_key = Some(b"key6_data".to_vec());
         domain6.not_before = Some(1700);
         domain6.not_after = Some(2700);
         state.domains.insert("dfinity.org".to_string(), domain6);
+        state.certificates.insert(
+            "dfinity.org".to_string(),
+            CertificateEntry {
+                enc_cert: b"cert6_data".to_vec(),
+                enc_priv_key: b"key6_data".to_vec(),
+            },
+        );
 
         state
     }
@@ -1246,14 +1477,20 @@ mod tests {
         let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
         let domains_memory = memory_manager.get(MemoryId::new(0));
         let last_change_memory = memory_manager.get(MemoryId::new(1));
+        let certs_memory = memory_manager.get(MemoryId::new(2));
+        let migrated_memory = memory_manager.get(MemoryId::new(3));
 
         let domains = StableBTreeMap::init(domains_memory);
         let last_change = StableCell::init(last_change_memory, 0);
+        let certificates = StableBTreeMap::init(certs_memory);
+        let certificates_migrated = StableCell::init(migrated_memory, false);
 
         let state = CanisterState {
             domains,
             last_change,
+            certificates,
             max_domains: MAX_STORED_DOMAINS,
+            certificates_migrated,
         };
 
         let input = ListCertificatesPageInput {
@@ -1491,7 +1728,6 @@ mod tests {
         // Certificate renewal check. 65% of the validity period has elapsed => no renewal task yet
         {
             let mut domain = DomainEntry::new(None, created_at);
-            domain.enc_cert = Some(b"cert_data".to_vec());
             let not_before = 500;
             let not_after = 2500;
             domain.not_before = Some(not_before);
@@ -1503,7 +1739,6 @@ mod tests {
         // Certificate renewal check. 67% of the validity period has elapsed => renewal task
         {
             let mut domain = DomainEntry::new(None, created_at);
-            domain.enc_cert = Some(b"cert_data".to_vec());
             let not_before = 500;
             let not_after = 2500;
             domain.not_before = Some(not_before);
@@ -1574,7 +1809,7 @@ mod tests {
         // generated Renew would re-issue without the wildcard SAN.
         let mut entry = state.domains.get(&domain).unwrap();
         entry.task = None; // simulate the issue task having completed
-        entry.enc_cert = Some(b"cert".to_vec()); // Update requires an existing certificate
+        entry.not_after = Some(9999); // Update requires an existing certificate
         state.domains.insert(domain.clone(), entry);
 
         state
@@ -1646,7 +1881,7 @@ mod tests {
         // Add a domain with previous failures
         let domain = "example.com".to_string();
         let mut domain_with_failures = DomainEntry::new(None, now);
-        domain_with_failures.enc_cert = Some(b"cert_data".to_vec());
+        domain_with_failures.not_after = Some(now + 9999);
         domain_with_failures.canister_id = Some(canister_id);
         domain_with_failures.failures_count = 5;
         domain_with_failures.rate_limit_failures_count = 3;
@@ -1697,7 +1932,7 @@ mod tests {
         // Test Update task on domain with certificate
         {
             let mut domain_for_update = DomainEntry::new(None, now);
-            domain_for_update.enc_cert = Some(b"cert_data".to_vec());
+            domain_for_update.not_after = Some(now + 9999);
             domain_for_update.canister_id = Some(canister_id);
             state
                 .domains
@@ -1718,7 +1953,7 @@ mod tests {
         // Test Delete task on domain with certificate
         {
             let mut domain_for_delete = DomainEntry::new(None, now);
-            domain_for_delete.enc_cert = Some(b"cert_data".to_vec());
+            domain_for_delete.not_after = Some(now + 9999);
             domain_for_delete.canister_id = Some(canister_id);
             state
                 .domains
@@ -1739,7 +1974,7 @@ mod tests {
         // Test Renew task on domain with certificate
         {
             let mut domain_for_renew = DomainEntry::new(None, now);
-            domain_for_renew.enc_cert = Some(b"cert_data".to_vec());
+            domain_for_renew.not_after = Some(now + 9999);
             domain_for_renew.canister_id = Some(canister_id);
             state
                 .domains
@@ -1809,7 +2044,7 @@ mod tests {
         // Test Issue task on domain with existing certificate is not allowed
         {
             let mut domain_with_cert = DomainEntry::new(None, now);
-            domain_with_cert.enc_cert = Some(b"cert_data".to_vec());
+            domain_with_cert.not_after = Some(now + 9999);
             domain_with_cert.canister_id = Some(canister_id);
             state
                 .domains
@@ -1831,7 +2066,7 @@ mod tests {
         // Test Renew task on domain with certificate should succeed
         {
             let mut domain_with_cert = DomainEntry::new(None, now);
-            domain_with_cert.enc_cert = Some(b"cert_data".to_vec());
+            domain_with_cert.not_after = Some(now + 9999);
             domain_with_cert.canister_id = Some(canister_id);
             state
                 .domains
@@ -1922,11 +2157,17 @@ mod tests {
         let now = 10000;
         state.domains.insert("renewal.com".to_string(), {
             let mut domain = DomainEntry::new(None, now - 5000);
-            domain.enc_cert = Some(b"cert_data".to_vec());
             domain.not_before = Some(0);
             domain.not_after = Some(now);
             domain
         });
+        state.certificates.insert(
+            "renewal.com".to_string(),
+            CertificateEntry {
+                enc_cert: b"cert_data".to_vec(),
+                enc_priv_key: b"key_data".to_vec(),
+            },
+        );
 
         // Act
         let result = state.fetch_next_task(now - 4000).unwrap();
@@ -1955,7 +2196,6 @@ mod tests {
         let mut domain = DomainEntry::new(Some(TaskKind::Renew), now - 5000);
         domain.taken_at = Some(task_id);
         domain.canister_id = Some(canister_id);
-        domain.enc_cert = Some(b"cert_data".to_vec());
         domain.not_before = Some(0);
         domain.not_after = Some(now);
         domain.failures_count = MAX_TASK_FAILURES - 1;
@@ -2007,7 +2247,6 @@ mod tests {
         // Scenario 1: Domain with valid certificate should NOT be removed
         {
             let mut domain_with_cert = DomainEntry::new(None, now - expiration_time - 3600);
-            domain_with_cert.enc_cert = Some(b"cert_data".to_vec());
             domain_with_cert.canister_id = Some(canister_id);
             domain_with_cert.not_after = Some(now + 3600); // Expires in 1 hour
             state
@@ -2053,21 +2292,24 @@ mod tests {
             let expired_grace = EXPIRED_DOMAIN_EXPIRATION_TIME.as_secs();
             let mut expired_cert_domain = DomainEntry::new(Some(TaskKind::Renew), now - 10000);
             expired_cert_domain.canister_id = Some(canister_id);
-            expired_cert_domain.enc_cert = Some(b"cert_data".to_vec());
-            expired_cert_domain.enc_priv_key = Some(b"key_data".to_vec());
             expired_cert_domain.not_before = Some(now - 900_000);
             expired_cert_domain.not_after = Some(now - expired_grace - 3600); // Expired >7 days ago
             state
                 .domains
                 .insert("expired-cert.com".to_string(), expired_cert_domain);
+            state.certificates.insert(
+                "expired-cert.com".to_string(),
+                CertificateEntry {
+                    enc_cert: b"cert_data".to_vec(),
+                    enc_priv_key: b"key_data".to_vec(),
+                },
+            );
         }
 
         // Scenario 7: Domain with certificate that expired less than 7 days ago should NOT be removed
         {
             let mut recent_expired = DomainEntry::new(None, now - 10000);
             recent_expired.canister_id = Some(canister_id);
-            recent_expired.enc_cert = Some(b"cert_data".to_vec());
-            recent_expired.enc_priv_key = Some(b"key_data".to_vec());
             recent_expired.not_before = Some(now - 10000);
             recent_expired.not_after = Some(now - 3600); // Expired 1 hour ago (< 7 days)
             state
@@ -2099,6 +2341,14 @@ mod tests {
         assert!(state.domains.get(&"old.com".to_string()).is_none());
         assert!(state.domains.get(&"just-expired.com".to_string()).is_none());
         assert!(state.domains.get(&"expired-cert.com".to_string()).is_none());
+
+        // The certificate for a removed domain must not linger orphaned
+        assert!(
+            state
+                .certificates
+                .get(&"expired-cert.com".to_string())
+                .is_none()
+        );
     }
 
     #[test]
@@ -2202,8 +2452,6 @@ mod tests {
 
         // Verify domain state updated correctly
         let domain_entry = state.domains.get(&"test.com".to_string()).unwrap();
-        assert_eq!(domain_entry.enc_cert, Some(certificate_data));
-        assert_eq!(domain_entry.enc_priv_key, Some(private_key_data));
         assert_eq!(domain_entry.not_before, Some(not_before));
         assert_eq!(domain_entry.not_after, Some(not_after));
         assert_eq!(domain_entry.canister_id, Some(canister_id));
@@ -2213,6 +2461,11 @@ mod tests {
         assert_eq!(domain_entry.rate_limit_failures_count, 0);
         assert_eq!(domain_entry.last_fail_time, None);
         assert_eq!(domain_entry.last_failure_reason, None);
+
+        // Verify the certificate landed in the certificates map, not the domain entry
+        let cert = state.certificates.get(&"test.com".to_string()).unwrap();
+        assert_eq!(cert.enc_cert, certificate_data);
+        assert_eq!(cert.enc_priv_key, private_key_data);
 
         // Verify last_change timestamp updated
         assert_eq!(*state.last_change.get(), now);
@@ -2230,9 +2483,14 @@ mod tests {
         let mut domain = DomainEntry::new(Some(TaskKind::Update), now);
         domain.taken_at = Some(task_id);
         domain.canister_id = Some(canister_id);
-        domain.enc_cert = Some(b"old_certificate".to_vec());
-        domain.enc_priv_key = Some(b"old_private_key".to_vec());
         state.domains.insert("test.com".to_string(), domain);
+        state.certificates.insert(
+            "test.com".to_string(),
+            CertificateEntry {
+                enc_cert: b"old_certificate".to_vec(),
+                enc_priv_key: b"old_private_key".to_vec(),
+            },
+        );
 
         let task_result = TaskResult {
             domain: "test.com".to_string(),
@@ -2255,8 +2513,9 @@ mod tests {
         assert_eq!(domain_entry.last_fail_time, None);
         assert_eq!(domain_entry.last_failure_reason, None);
         // Certificate and private key should remain unchanged
-        assert_eq!(domain_entry.enc_cert, Some(b"old_certificate".to_vec()));
-        assert_eq!(domain_entry.enc_priv_key, Some(b"old_private_key".to_vec()));
+        let cert = state.certificates.get(&"test.com".to_string()).unwrap();
+        assert_eq!(cert.enc_cert, b"old_certificate");
+        assert_eq!(cert.enc_priv_key, b"old_private_key");
 
         // Verify last_change timestamp updated
         assert_eq!(*state.last_change.get(), now);
@@ -2273,9 +2532,14 @@ mod tests {
         let mut domain = DomainEntry::new(Some(TaskKind::Delete), now);
         domain.taken_at = Some(task_id);
         domain.canister_id = Some(canister_id);
-        domain.enc_cert = Some(b"certificate_data".to_vec());
-        domain.enc_priv_key = Some(b"private_key_data".to_vec());
         state.domains.insert("test.com".to_string(), domain);
+        state.certificates.insert(
+            "test.com".to_string(),
+            CertificateEntry {
+                enc_cert: b"certificate_data".to_vec(),
+                enc_priv_key: b"private_key_data".to_vec(),
+            },
+        );
 
         let task_result = TaskResult {
             domain: "test.com".to_string(),
@@ -2290,6 +2554,9 @@ mod tests {
 
         // Verify domain was completely removed
         assert!(state.domains.get(&"test.com".to_string()).is_none());
+
+        // The certificate must not linger orphaned in the certificates map
+        assert!(state.certificates.get(&"test.com".to_string()).is_none());
 
         // Verify last_change timestamp updated
         assert_eq!(*state.last_change.get(), now);
@@ -2306,11 +2573,16 @@ mod tests {
         let mut domain = DomainEntry::new(Some(TaskKind::Renew), now);
         domain.taken_at = Some(task_id);
         domain.canister_id = Some(canister_id);
-        domain.enc_cert = Some(b"old_certificate".to_vec());
-        domain.enc_priv_key = Some(b"old_private_key".to_vec());
         domain.not_before = Some(500);
         domain.not_after = Some(1500);
         state.domains.insert("test.com".to_string(), domain);
+        state.certificates.insert(
+            "test.com".to_string(),
+            CertificateEntry {
+                enc_cert: b"old_certificate".to_vec(),
+                enc_priv_key: b"old_private_key".to_vec(),
+            },
+        );
 
         let new_certificate_data = b"new_certificate_data".to_vec();
         let new_private_key_data = b"new_private_key_data".to_vec();
@@ -2335,8 +2607,6 @@ mod tests {
 
         // Verify domain state updated correctly
         let domain_entry = state.domains.get(&"test.com".to_string()).unwrap();
-        assert_eq!(domain_entry.enc_cert, Some(new_certificate_data));
-        assert_eq!(domain_entry.enc_priv_key, Some(new_private_key_data));
         assert_eq!(domain_entry.not_before, Some(new_not_before));
         assert_eq!(domain_entry.not_after, Some(new_not_after));
         assert_eq!(domain_entry.task, None);
@@ -2345,6 +2615,11 @@ mod tests {
         assert_eq!(domain_entry.rate_limit_failures_count, 0);
         assert_eq!(domain_entry.last_fail_time, None);
         assert_eq!(domain_entry.last_failure_reason, None);
+
+        // Verify the certificate was replaced with the new one
+        let cert = state.certificates.get(&"test.com".to_string()).unwrap();
+        assert_eq!(cert.enc_cert, new_certificate_data);
+        assert_eq!(cert.enc_priv_key, new_private_key_data);
 
         // Verify last_change timestamp updated
         assert_eq!(*state.last_change.get(), now);
@@ -2389,8 +2664,9 @@ mod tests {
 
         // Verify all failure state was cleared on success
         let domain_entry = state.domains.get(&"test.com".to_string()).unwrap();
-        assert_eq!(domain_entry.enc_cert, Some(certificate_data));
-        assert_eq!(domain_entry.enc_priv_key, Some(private_key_data));
+        let cert = state.certificates.get(&"test.com".to_string()).unwrap();
+        assert_eq!(cert.enc_cert, certificate_data);
+        assert_eq!(cert.enc_priv_key, private_key_data);
         assert_eq!(domain_entry.task, None);
         assert_eq!(domain_entry.taken_at, None);
         assert_eq!(domain_entry.failures_count, 0);

--- a/custom-domains/canister/src/state.rs
+++ b/custom-domains/canister/src/state.rs
@@ -1,5 +1,4 @@
-use std::hash::Hash;
-use std::{borrow::Cow, collections::HashMap, ops::Bound as RangeBound};
+use std::{borrow::Cow, collections::HashMap, hash::Hash, ops::Bound as RangeBound};
 
 use candid::Principal;
 use ic_custom_domains_canister_api::{
@@ -35,40 +34,40 @@ pub type UtcTimestamp = u64;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DomainEntry {
-    // Current task being processed for the domain, if any
+    /// Current task being processed for the domain, if any
     pub task: Option<TaskKind>,
-    // Timestamp when the task failed last time, if any
+    /// Timestamp when the task failed last time, if any
     pub last_fail_time: Option<UtcTimestamp>,
-    // Reason for the last failure, if any
+    /// Reason for the last failure, if any
     pub last_failure_reason: Option<TaskFailReason>,
-    // Number of consecutive failures for the current task (excluding rate limit failures)
+    /// Number of consecutive failures for the current task (excluding rate limit failures)
     pub failures_count: u32,
-    // Number of rate limit failures for the current task
+    /// Number of rate limit failures for the current task
     pub rate_limit_failures_count: u32,
-    // Canister ID associated with the domain
+    /// Canister ID associated with the domain
     pub canister_id: Option<Principal>,
-    // Timestamp when the domain entry was created (set once and never updated)
+    /// Timestamp when the domain entry was created (set once and never updated)
     pub created_at: UtcTimestamp,
-    // Timestamp when the current task was taken by a worker
+    /// Timestamp when the current task was taken by a worker
     pub taken_at: Option<UtcTimestamp>,
-    // Timestamp when the current task was created
+    /// Timestamp when the current task was created
     pub task_created_at: Option<UtcTimestamp>,
-    // Certificate validity period start (as UNIX timestamp)
+    /// Certificate validity period start (as UNIX timestamp)
     pub not_before: Option<UtcTimestamp>,
-    // Certificate validity period end (as UNIX timestamp)
+    /// Certificate validity period end (as UNIX timestamp)
     pub not_after: Option<UtcTimestamp>,
-    // Whether to also issue a `*.domain` wildcard SAN in the certificate.
-    // `#[serde(default)]` keeps existing stable-storage entries deserializable
-    // after upgrade (they predate this field and default to `false`).
+    /// Whether to also issue a `*.domain` wildcard SAN in the certificate.
+    /// `#[serde(default)]` keeps existing stable-storage entries deserializable
+    /// after upgrade (they predate this field and default to `false`).
     #[serde(default)]
     pub wildcard: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CertificateEntry {
-    // PEM-encoded certificate data (encrypted)
+    /// PEM-encoded certificate data (encrypted)
     pub enc_cert: Vec<u8>,
-    // PEM-encoded private key data (encrypted)
+    /// PEM-encoded private key data (encrypted)
     pub enc_priv_key: Vec<u8>,
 }
 
@@ -88,54 +87,12 @@ impl Storable for CertificateEntry {
     }
 }
 
-/// Mirrors `DomainEntry`'s on-disk shape from before `enc_cert`/`enc_priv_key` were split
-/// out into `CertificateEntry`. Used only to recover those fields from stable memory
-/// during the one-time post-upgrade migration; `#[serde(default)]` on both fields lets it
-/// also parse already-migrated (trimmed) bytes without error, so re-running the migration
-/// stays safe even though it is guarded to run only once.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct DomainEntryV1 {
-    task: Option<TaskKind>,
-    last_fail_time: Option<UtcTimestamp>,
-    last_failure_reason: Option<TaskFailReason>,
-    failures_count: u32,
-    rate_limit_failures_count: u32,
-    canister_id: Option<Principal>,
-    created_at: UtcTimestamp,
-    taken_at: Option<UtcTimestamp>,
-    task_created_at: Option<UtcTimestamp>,
-    #[serde(default)]
-    enc_cert: Option<Vec<u8>>,
-    #[serde(default)]
-    enc_priv_key: Option<Vec<u8>>,
-    not_before: Option<UtcTimestamp>,
-    not_after: Option<UtcTimestamp>,
-    #[serde(default)]
-    wildcard: bool,
-}
-
-impl Storable for DomainEntryV1 {
-    const BOUND: Bound = Bound::Unbounded;
-
-    fn to_bytes(&self) -> std::borrow::Cow<'_, [u8]> {
-        Cow::Owned(to_vec(&self).expect("DomainEntryV1 serialization failed"))
-    }
-
-    fn into_bytes(self) -> Vec<u8> {
-        to_vec(&self).expect("DomainEntryV1 serialization failed")
-    }
-
-    fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {
-        from_slice(&bytes).expect("DomainEntryV1 deserialization failed")
-    }
-}
-
 #[derive(Debug, Clone, Eq, PartialEq, Hash, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum TaskStatus {
-    // Task is pending and has not been taken by any worker yet
+    /// Task is pending and has not been taken by any worker yet
     Pending(TaskKind),
-    // Task is currently being processed by a worker
+    /// Task is currently being processed by a worker
     InProgress(TaskKind),
 }
 
@@ -148,7 +105,7 @@ impl TaskStatus {
     }
 }
 
-// Simplified registration status labels for metrics and stats
+/// Simplified registration status labels for metrics and stats
 #[derive(Debug, Clone, Eq, PartialEq, Hash, EnumIter, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum RegistrationStatusLabel {
@@ -258,85 +215,10 @@ pub struct CanisterState {
     pub last_change: StableCell<UtcTimestamp, VirtualMemory<DefaultMemoryImpl>>,
     pub certificates: StableBTreeMap<String, CertificateEntry, VirtualMemory<DefaultMemoryImpl>>,
     pub max_domains: u64,
-    /// Guards `migrate_certificates_out_of_domains`, so the one-time rewrite of every
-    /// domain entry only ever runs on the first post-upgrade after this migration shipped.
-    pub certificates_migrated: StableCell<bool, VirtualMemory<DefaultMemoryImpl>>,
 }
 
 impl CanisterState {
-    /// One-time migration: moves `enc_cert`/`enc_priv_key` out of each `DomainEntry` and
-    /// into the `certificates` map, then rewrites the (now smaller) entry back into
-    /// `domains`. Before this ran, every full scan over `domains` (stats, cleanup, task
-    /// scheduling) had to decode the certificate/key bytes of every entry just to skip
-    /// past them, which is what made those scans expensive.
-    ///
-    /// Safe to call on every post_upgrade: guarded by `certificates_migrated` so it's a
-    /// no-op after the first run, and reads legacy bytes through `DomainEntryV1`, whose
-    /// `#[serde(default)]` cert fields also parse already-migrated entries without error.
-    ///
-    /// Reads proceed key-by-key via point lookups (`get`), never a live iterator held
-    /// across a mutation of `domains`/`certificates` on the same underlying stable memory.
-    /// `domains_memory` must be a *second* handle onto the same memory region backing
-    /// `self.domains` (e.g. another `MEMORY_MANAGER.get(MemoryId::new(0))` call) — taken as
-    /// a parameter, rather than reached for internally, so this stays testable against
-    /// any `CanisterState`/`MemoryManager` pairing instead of only the real canister's.
-    pub fn migrate_certificates_out_of_domains(
-        &mut self,
-        domains_memory: VirtualMemory<DefaultMemoryImpl>,
-    ) {
-        if *self.certificates_migrated.get() {
-            return;
-        }
-
-        let legacy_domains: StableBTreeMap<
-            String,
-            DomainEntryV1,
-            VirtualMemory<DefaultMemoryImpl>,
-        > = StableBTreeMap::init(domains_memory);
-
-        let domain_keys: Vec<String> = self.domains.keys().collect();
-
-        for domain in domain_keys {
-            let Some(legacy_entry) = legacy_domains.get(&domain) else {
-                continue;
-            };
-
-            if let (Some(enc_cert), Some(enc_priv_key)) = (
-                legacy_entry.enc_cert.clone(),
-                legacy_entry.enc_priv_key.clone(),
-            ) {
-                self.certificates.insert(
-                    domain.clone(),
-                    CertificateEntry {
-                        enc_cert,
-                        enc_priv_key,
-                    },
-                );
-            }
-
-            self.domains.insert(
-                domain,
-                DomainEntry {
-                    task: legacy_entry.task,
-                    last_fail_time: legacy_entry.last_fail_time,
-                    last_failure_reason: legacy_entry.last_failure_reason,
-                    failures_count: legacy_entry.failures_count,
-                    rate_limit_failures_count: legacy_entry.rate_limit_failures_count,
-                    canister_id: legacy_entry.canister_id,
-                    created_at: legacy_entry.created_at,
-                    taken_at: legacy_entry.taken_at,
-                    task_created_at: legacy_entry.task_created_at,
-                    not_before: legacy_entry.not_before,
-                    not_after: legacy_entry.not_after,
-                    wildcard: legacy_entry.wildcard,
-                },
-            );
-        }
-
-        self.certificates_migrated.set(true);
-    }
-
-    // Processes all domains and returns true if next task exists.
+    /// Processes all domains and returns true if next task exists.
     pub fn has_next_task(&self, now: UtcTimestamp) -> HasNextTaskResult {
         let has_task = self
             .domains
@@ -423,7 +305,7 @@ impl CanisterState {
         }
     }
 
-    // Compute statistics about the domains and tasks
+    /// Compute statistics about the domains and tasks
     pub fn compute_stats(&self, now: UtcTimestamp) -> Stats {
         let mut domains_nearing_expiration = 0;
         let mut registration_statuses: HashMap<_, _> = HashMap::new();
@@ -504,7 +386,7 @@ impl CanisterState {
         Ok(Some(domain_entry_to_api(entry, cert)))
     }
 
-    // Removes unregistered domains that have been in the system for too long
+    /// Removes unregistered domains that have been in the system for too long
     pub fn cleanup_stale_domains(&mut self, now: UtcTimestamp) {
         let mut domains_to_remove = Vec::new();
 
@@ -1066,118 +948,21 @@ mod tests {
         assert_eq!(entry.created_at, 1000);
     }
 
-    /// `migrate_certificates_out_of_domains` must move `enc_cert`/`enc_priv_key` out of
-    /// stable-storage bytes written by a pre-migration canister and into the certificates
-    /// map, then rewrite the domain entry without them.
-    #[test]
-    fn test_migrate_certificates_out_of_domains() {
-        // Built by hand (rather than via `create_test_empty_state`) so the test keeps its
-        // own `MemoryManager` around: a second `.get(MemoryId::new(0))` call on that same
-        // manager is what gives `legacy_domains` a view onto the exact bytes `state.domains`
-        // is backed by.
-        let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
-
-        // Write raw legacy-shaped bytes directly into the domains memory region, exactly as
-        // a pre-migration canister would have, bypassing the (already trimmed) `DomainEntry`
-        // Storable impl. This must happen *before* `state.domains` below is constructed:
-        // `StableBTreeMap::init` caches the tree's root address/length in Rust-level fields
-        // at construction time (mirroring `BTreeHeader`), so it only sees data already on
-        // disk at that point — exactly like a real upgrade, where the previous canister run's
-        // data is on disk before the new run's `STATE` is lazily initialized.
-        let mut legacy_domains: StableBTreeMap<
-            String,
-            DomainEntryV1,
-            VirtualMemory<DefaultMemoryImpl>,
-        > = StableBTreeMap::init(memory_manager.get(MemoryId::new(0)));
-        legacy_domains.insert(
-            "example.com".to_string(),
-            DomainEntryV1 {
-                task: None,
-                last_fail_time: None,
-                last_failure_reason: None,
-                failures_count: 0,
-                rate_limit_failures_count: 0,
-                canister_id: Some(Principal::from_text("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap()),
-                created_at: 1000,
-                taken_at: None,
-                task_created_at: None,
-                enc_cert: Some(b"cert_data".to_vec()),
-                enc_priv_key: Some(b"key_data".to_vec()),
-                not_before: Some(1500),
-                not_after: Some(2500),
-                wildcard: true,
-            },
-        );
-        // A domain that never had a certificate issued must not gain a spurious entry.
-        legacy_domains.insert(
-            "pending.net".to_string(),
-            DomainEntryV1 {
-                task: Some(TaskKind::Issue),
-                last_fail_time: None,
-                last_failure_reason: None,
-                failures_count: 0,
-                rate_limit_failures_count: 0,
-                canister_id: None,
-                created_at: 1200,
-                taken_at: None,
-                task_created_at: None,
-                enc_cert: None,
-                enc_priv_key: None,
-                not_before: None,
-                not_after: None,
-                wildcard: false,
-            },
-        );
-
-        let mut state = CanisterState {
-            domains: StableBTreeMap::init(memory_manager.get(MemoryId::new(0))),
-            last_change: StableCell::init(memory_manager.get(MemoryId::new(1)), 0),
-            certificates: StableBTreeMap::init(memory_manager.get(MemoryId::new(2))),
-            max_domains: MAX_STORED_DOMAINS,
-            certificates_migrated: StableCell::init(memory_manager.get(MemoryId::new(3)), false),
-        };
-
-        state.migrate_certificates_out_of_domains(memory_manager.get(MemoryId::new(0)));
-
-        let cert = state
-            .certificates
-            .get(&"example.com".to_string())
-            .expect("certificate should have been migrated");
-        assert_eq!(cert.enc_cert, b"cert_data");
-        assert_eq!(cert.enc_priv_key, b"key_data");
-        assert!(state.certificates.get(&"pending.net".to_string()).is_none());
-
-        let entry = state.domains.get(&"example.com".to_string()).unwrap();
-        assert_eq!(entry.not_before, Some(1500));
-        assert_eq!(entry.not_after, Some(2500));
-        assert!(entry.wildcard);
-
-        assert!(*state.certificates_migrated.get());
-
-        // Re-running must be a no-op: it's guarded by `certificates_migrated`, so a second
-        // call must not resurrect anything even if the raw legacy bytes were still there.
-        state.migrate_certificates_out_of_domains(memory_manager.get(MemoryId::new(0)));
-        assert_eq!(state.certificates.len(), 1);
-    }
-
     fn create_test_empty_state() -> CanisterState {
         let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
         let domains_memory = memory_manager.get(MemoryId::new(0));
         let last_change_memory = memory_manager.get(MemoryId::new(1));
         let certs_memory = memory_manager.get(MemoryId::new(2));
-        let migrated_memory = memory_manager.get(MemoryId::new(3));
 
         let domains = StableBTreeMap::init(domains_memory);
         let last_change = StableCell::init(last_change_memory, 0);
         let certificates = StableBTreeMap::init(certs_memory);
-        let certificates_migrated = StableCell::init(migrated_memory, false);
 
         CanisterState {
             domains,
             last_change,
             certificates,
             max_domains: MAX_STORED_DOMAINS,
-            certificates_migrated,
         }
     }
 
@@ -1187,19 +972,16 @@ mod tests {
         let domains_memory = memory_manager.get(MemoryId::new(0));
         let last_change_memory = memory_manager.get(MemoryId::new(1));
         let certs_memory = memory_manager.get(MemoryId::new(2));
-        let migrated_memory = memory_manager.get(MemoryId::new(3));
 
         let domains = StableBTreeMap::init(domains_memory);
         let last_change = StableCell::init(last_change_memory, 0);
         let certificates = StableBTreeMap::init(certs_memory);
-        let certificates_migrated = StableCell::init(migrated_memory, false);
 
         let mut state = CanisterState {
             domains,
             last_change,
             certificates,
             max_domains: MAX_STORED_DOMAINS,
-            certificates_migrated,
         };
 
         let canister_id_1 = Principal::from_text("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap();
@@ -1478,19 +1260,16 @@ mod tests {
         let domains_memory = memory_manager.get(MemoryId::new(0));
         let last_change_memory = memory_manager.get(MemoryId::new(1));
         let certs_memory = memory_manager.get(MemoryId::new(2));
-        let migrated_memory = memory_manager.get(MemoryId::new(3));
 
         let domains = StableBTreeMap::init(domains_memory);
         let last_change = StableCell::init(last_change_memory, 0);
         let certificates = StableBTreeMap::init(certs_memory);
-        let certificates_migrated = StableCell::init(migrated_memory, false);
 
         let state = CanisterState {
             domains,
             last_change,
             certificates,
             max_domains: MAX_STORED_DOMAINS,
-            certificates_migrated,
         };
 
         let input = ListCertificatesPageInput {

--- a/custom-domains/canister/src/storage.rs
+++ b/custom-domains/canister/src/storage.rs
@@ -12,9 +12,7 @@ use crate::state::CanisterState;
 pub const MAX_STORED_DOMAINS: u64 = 1_000_000;
 
 thread_local! {
-    // `pub(crate)` so the certificate migration in `state.rs` can open a second, temporary
-    // view over the domains memory region (MemoryId 0) using the pre-migration entry shape.
-    pub(crate) static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
+    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
         RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
 
     pub static AUTHORIZED_PRINCIPAL: RefCell<Option<Principal>> = RefCell::default();
@@ -25,7 +23,6 @@ thread_local! {
             last_change: StableCell::init(MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(1))), 0),
             certificates: StableBTreeMap::init(MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(2)))),
             max_domains: MAX_STORED_DOMAINS,
-            certificates_migrated: StableCell::init(MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(3))), false),
         }
     );
 }

--- a/custom-domains/canister/src/storage.rs
+++ b/custom-domains/canister/src/storage.rs
@@ -8,11 +8,13 @@ use ic_stable_structures::{
 
 use crate::state::CanisterState;
 
-// Maximum number of domains stored in the canister
+/// Maximum number of domains stored in the canister
 pub const MAX_STORED_DOMAINS: u64 = 1_000_000;
 
 thread_local! {
-    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
+    // `pub(crate)` so the certificate migration in `state.rs` can open a second, temporary
+    // view over the domains memory region (MemoryId 0) using the pre-migration entry shape.
+    pub(crate) static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
         RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
 
     pub static AUTHORIZED_PRINCIPAL: RefCell<Option<Principal>> = RefCell::default();
@@ -21,7 +23,9 @@ thread_local! {
         CanisterState {
             domains: StableBTreeMap::init(MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(0)))),
             last_change: StableCell::init(MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(1))), 0),
+            certificates: StableBTreeMap::init(MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(2)))),
             max_domains: MAX_STORED_DOMAINS,
+            certificates_migrated: StableCell::init(MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(3))), false),
         }
     );
 }

--- a/ic-bn-lib/src/custom_domains/tests/helpers.rs
+++ b/ic-bn-lib/src/custom_domains/tests/helpers.rs
@@ -43,14 +43,25 @@ impl TestEnv {
         authorized_principal: Option<Principal>,
         sender: Principal,
     ) -> anyhow::Result<Self> {
+        Self::new_with_wasm_env("CANISTER_WASM_PATH", authorized_principal, sender).await
+    }
+
+    /// Like `new`, but loads the canister WASM from a caller-specified env var instead of the
+    /// default `CANISTER_WASM_PATH`. Useful for tests that need a WASM built with non-default
+    /// features (e.g. the `bench` feature), which is built separately from the main test WASM.
+    pub async fn new_with_wasm_env(
+        wasm_path_env_var: &str,
+        authorized_principal: Option<Principal>,
+        sender: Principal,
+    ) -> anyhow::Result<Self> {
         info!("pocket-ic server starting ...");
 
         let pic = PocketIcBuilder::new().with_nns_subnet().build_async().await;
 
         info!("pocket-ic server started");
 
-        let wasm_path =
-            std::env::var("CANISTER_WASM_PATH").expect("CANISTER_WASM_PATH env var not set");
+        let wasm_path = std::env::var(wasm_path_env_var)
+            .unwrap_or_else(|_| panic!("{wasm_path_env_var} env var not set"));
 
         let wasm = fs::read(PathBuf::from(wasm_path)).context("unable to load WASM")?;
 

--- a/ic-bn-lib/src/custom_domains/tests/instruction_scaling_test.rs
+++ b/ic-bn-lib/src/custom_domains/tests/instruction_scaling_test.rs
@@ -1,0 +1,142 @@
+//! Measures how many WASM instructions `CanisterState`'s full-scan methods
+//! (`has_next_task`, `fetch_next_task`, `compute_stats`, `domains_nearing_expiration`,
+//! `cleanup_stale_domains`) consume as a function of the number of domains held, then
+//! extrapolates the domain count at which each would hit the IC's 40B-instruction
+//! per-message budget.
+//!
+//! Requires a canister WASM built with the `bench` feature (see `BENCH_CANISTER_WASM_PATH`
+//! in `run_tests.sh`), which adds test-only endpoints to seed synthetic domains directly into
+//! stable storage and to report `ic_cdk::api::instruction_counter()` deltas around a call.
+
+use anyhow::anyhow;
+use candid::{CandidType, Decode, Encode, Principal};
+use serde::Deserialize;
+use tracing::info;
+
+use super::helpers::{TestEnv, init_logging};
+
+/// Per-message instruction limit enforced by the IC for a single update/query call execution.
+const INSTRUCTION_LIMIT: u64 = 40_000_000_000;
+
+/// Domain counts to sample. Kept well below `MAX_STORED_DOMAINS` (1_000_000) so the run stays
+/// fast; the linear scaling law measured over these points is then extrapolated further.
+const SAMPLE_POINTS: [u64; 5] = [0, 5_000, 20_000, 50_000, 100_000];
+
+/// Synthetic domains seeded per `bench_seed_domains` call, chosen to keep each seeding call
+/// itself comfortably under the instruction limit.
+const SEED_CHUNK: u64 = 20_000;
+
+/// Mirrors `ic_custom_domains_canister::bench::BenchMethod`. Candid matches enum variants by
+/// name, not declaration order, so this only needs matching variant names.
+#[derive(CandidType, Deserialize, Clone, Copy, Debug)]
+enum BenchMethod {
+    HasNextTask,
+    FetchNextTask,
+    ComputeStats,
+    DomainsNearingExpiration,
+    CleanupStaleDomains,
+}
+
+const METHODS: [(&str, BenchMethod); 5] = [
+    ("has_next_task", BenchMethod::HasNextTask),
+    ("fetch_next_task", BenchMethod::FetchNextTask),
+    ("compute_stats", BenchMethod::ComputeStats),
+    (
+        "domains_nearing_expiration",
+        BenchMethod::DomainsNearingExpiration,
+    ),
+    ("cleanup_stale_domains", BenchMethod::CleanupStaleDomains),
+];
+
+async fn seed_up_to(env: &TestEnv, target: u64, mut current: u64) -> anyhow::Result<u64> {
+    while current < target {
+        let chunk = (target - current).min(SEED_CHUNK);
+        let arg = Encode!(&chunk, &current)?;
+
+        env.pic
+            .update_call(env.canister_id, env.sender, "bench_seed_domains", arg)
+            .await
+            .map_err(|e| anyhow!("bench_seed_domains failed: {e}"))?;
+
+        current += chunk;
+    }
+
+    Ok(current)
+}
+
+async fn measure(env: &TestEnv, method: BenchMethod) -> anyhow::Result<u64> {
+    let arg = Encode!(&method)?;
+
+    let result = env
+        .pic
+        .update_call(env.canister_id, env.sender, "bench_measure", arg)
+        .await
+        .map_err(|e| anyhow!("bench_measure failed: {e}"))?;
+
+    Decode!(&result, u64).map_err(|e| anyhow!("failed to decode bench_measure result: {e}"))
+}
+
+/// Ordinary least-squares fit of `instructions ~= intercept + slope * domains`.
+fn linear_fit(points: &[(f64, f64)]) -> (f64, f64) {
+    let n = points.len() as f64;
+    let sum_x: f64 = points.iter().map(|(x, _)| x).sum();
+    let sum_y: f64 = points.iter().map(|(_, y)| y).sum();
+    let sum_xx: f64 = points.iter().map(|(x, _)| x * x).sum();
+    let sum_xy: f64 = points.iter().map(|(x, y)| x * y).sum();
+
+    let slope = n.mul_add(sum_xy, -(sum_x * sum_y)) / n.mul_add(sum_xx, -(sum_x * sum_x));
+    let intercept = slope.mul_add(-sum_x, sum_y) / n;
+
+    (slope, intercept)
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_instruction_scaling_with_domain_count() -> anyhow::Result<()> {
+    init_logging();
+
+    let sender = Principal::from_text("oqjvn-fqaaa-aaaab-qab5q-cai")?;
+    let env = TestEnv::new_with_wasm_env("BENCH_CANISTER_WASM_PATH", Some(sender), sender).await?;
+
+    let mut current: u64 = 0;
+    // instructions[method_index][sample_index]
+    let mut instructions: Vec<Vec<u64>> = vec![Vec::new(); METHODS.len()];
+
+    for &n in &SAMPLE_POINTS {
+        current = seed_up_to(&env, n, current).await?;
+
+        for (i, (name, method)) in METHODS.iter().enumerate() {
+            let used = measure(&env, *method).await?;
+            info!("domains={n:>8} {name:<28} instructions={used}");
+            instructions[i].push(used);
+
+            assert!(
+                used < INSTRUCTION_LIMIT,
+                "{name} used {used} instructions with {n} domains, exceeding the {INSTRUCTION_LIMIT} budget"
+            );
+        }
+    }
+
+    info!("--- extrapolation to the 40B instruction budget ---");
+    for (i, (name, _)) in METHODS.iter().enumerate() {
+        let points: Vec<(f64, f64)> = SAMPLE_POINTS
+            .iter()
+            .zip(&instructions[i])
+            .map(|(&n, &used)| (n as f64, used as f64))
+            .collect();
+
+        let (per_domain, fixed) = linear_fit(&points);
+        let max_domains = if per_domain > 0.0 {
+            ((INSTRUCTION_LIMIT as f64 - fixed) / per_domain) as i64
+        } else {
+            i64::MAX
+        };
+
+        info!(
+            "{name}: ~{per_domain:.2} instructions/domain + {fixed:.0} fixed overhead => \
+             estimated max ~{max_domains} domains before hitting the {INSTRUCTION_LIMIT} instruction budget"
+        );
+    }
+
+    Ok(())
+}

--- a/ic-bn-lib/src/custom_domains/tests/mod.rs
+++ b/ic-bn-lib/src/custom_domains/tests/mod.rs
@@ -19,6 +19,7 @@ const RATE_LIMIT_MAX_ATTEMPTS: u32 = 25;
 
 mod e2e_test;
 mod helpers;
+mod instruction_scaling_test;
 
 #[ignore]
 #[tokio::test]

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -37,6 +37,9 @@ log "Building the canister wasm with the bench feature"
 CARGO_TARGET_DIR="${BENCH_CANISTER_TARGET_DIR}" cargo build --package ic-custom-domains-canister --target wasm32-unknown-unknown --release --features bench || { log "Failed to build the bench canister wasm"; exit 1; }
 log "Bench canister wasm built successfully at ${BENCH_CANISTER_WASM_PATH}"
 
+log "Running canister interface compatibility test (without bench feature)"
+cargo test --profile dev -p ic-custom-domains-canister --lib || { log "Canister unit tests failed"; exit 1; }
+
 log "Running unit tests using all features enabled"
 cargo test --all-features --profile dev --workspace --lib || { log "Unit tests failed"; exit 1; }
 log "Unit tests completed successfully"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -8,6 +8,10 @@ readonly WORKDIR="$(pwd)"
 export POCKET_IC_BIN="${WORKDIR}/pocket-ic"
 export CARGO_TARGET_DIR="${WORKDIR}/target"
 export CANISTER_WASM_PATH="${CARGO_TARGET_DIR}/wasm32-unknown-unknown/release/ic_custom_domains_canister.wasm"
+# Separate target dir: the `bench` feature adds test-only instrumentation endpoints that must
+# never ship in the WASM used by the other (non-`--features bench`) tests above.
+export BENCH_CANISTER_TARGET_DIR="${WORKDIR}/target/bench"
+export BENCH_CANISTER_WASM_PATH="${BENCH_CANISTER_TARGET_DIR}/wasm32-unknown-unknown/release/ic_custom_domains_canister.wasm"
 
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" >&2; }
 
@@ -28,6 +32,10 @@ log "PocketIC setup completed"
 log "Building the canister wasm"
 cargo build --package ic-custom-domains-canister --target wasm32-unknown-unknown --release || { log "Failed to build the canister wasm"; exit 1; }
 log "Canister wasm built successfully at ${CANISTER_WASM_PATH}"
+
+log "Building the canister wasm with the bench feature"
+CARGO_TARGET_DIR="${BENCH_CANISTER_TARGET_DIR}" cargo build --package ic-custom-domains-canister --target wasm32-unknown-unknown --release --features bench || { log "Failed to build the bench canister wasm"; exit 1; }
+log "Bench canister wasm built successfully at ${BENCH_CANISTER_WASM_PATH}"
 
 log "Running unit tests using all features enabled"
 cargo test --all-features --profile dev --workspace --lib || { log "Unit tests failed"; exit 1; }


### PR DESCRIPTION
Also add test/benchmark to determine how many instructions does canister consume