### PR TITLE
Rework ACME a bit, update some crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -242,7 +242,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -254,7 +254,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -359,7 +359,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -636,14 +636,14 @@ checksum = "f48d6ace212fdf1b45fd6b566bb40808415344642b76c3224c07c8df9da81e97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -722,6 +722,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,14 +806,14 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "candid_parser"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470a4cf0c110e217e54ab3d21c4a9c290736c4a70ab6263d65155522d4b93fb6"
+checksum = "2e35c12ed409a6c02c6e204db49926c75ceeb622a4a994b828cdd3dea7dfec59"
 dependencies = [
  "anyhow",
  "candid",
@@ -940,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -950,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -969,7 +979,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1250,7 +1260,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1297,7 +1307,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1310,7 +1320,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1321,7 +1331,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1332,7 +1342,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1404,7 +1414,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1424,7 +1434,7 @@ checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1435,7 +1445,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1456,7 +1466,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1466,7 +1476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1551,7 +1561,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1973,7 +1983,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2219,7 +2229,7 @@ dependencies = [
  "indexmap 2.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2611,7 +2621,7 @@ dependencies = [
  "ic-custom-domains-canister-api",
  "indoc",
  "instant-acme",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "mail-auth",
  "mail-parser",
  "mail-send",
@@ -2658,7 +2668,7 @@ dependencies = [
  "tokio-test",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.7.0",
  "tower-service",
  "tower_governor",
  "tracing",
@@ -2711,7 +2721,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3165,6 +3175,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,7 +3216,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3216,7 +3235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3457,7 +3476,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3486,9 +3505,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.6"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]
@@ -3501,12 +3520,14 @@ checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "mail-auth"
-version = "0.9.2"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3c5a279d798bf41bfcf94ee593a34b545fb2010ebf5cfce3416d6b4019f697"
+checksum = "5dc03ec0f6be1788623ee3d275940ca0053ced3154eb881ffe70edf2f43d3d41"
 dependencies = [
  "aws-lc-rs",
  "flate2",
+ "getrandom 0.2.17",
+ "getrandom 0.4.3",
  "hashify",
  "hickory-resolver",
  "mail-builder",
@@ -3515,6 +3536,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
+ "similar",
  "zip 8.6.0",
 ]
 
@@ -3666,7 +3688,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3700,9 +3722,9 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -4087,7 +4109,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4151,7 +4173,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4431,7 +4453,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4496,9 +4518,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -4786,7 +4808,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4806,9 +4828,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4818,9 +4840,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4880,7 +4902,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4926,7 +4948,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5006,7 +5028,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.118",
+ "syn 2.0.119",
  "walkdir",
 ]
 
@@ -5246,7 +5268,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5349,7 +5371,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5360,7 +5382,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5396,7 +5418,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5449,20 +5471,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.14.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5603,15 +5612,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -5622,6 +5631,15 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "siphasher"
@@ -5686,14 +5704,14 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5701,9 +5719,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spinning_top"
@@ -5807,7 +5825,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5819,7 +5837,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5853,9 +5871,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5879,7 +5897,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6010,7 +6028,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6021,7 +6039,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6125,7 +6143,7 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6163,7 +6181,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6317,8 +6335,24 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
  "url",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "percent-encoding",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6383,7 +6417,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6601,7 +6635,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6656,14 +6690,16 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vrl"
-version = "0.33.1"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772206835b5bca8719825d2ab9e6fb160cbfce8ac1dc0e5dffe22cbe77254468"
+checksum = "90d4f0baccba853b3e8420356e8b27662c7971657c17f0260beef35e169f2dc1"
 dependencies = [
  "bytes",
  "cfg-if",
  "chrono",
+ "getrandom 0.2.17",
  "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "jsonschema",
  "lalrpop 0.22.2",
  "lz4_flex",
@@ -6672,7 +6708,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "serde_yaml",
  "serde_yaml_ng",
  "simdutf8",
  "snafu",
@@ -6763,7 +6798,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -6907,7 +6942,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6918,7 +6953,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7160,7 +7195,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -7181,7 +7216,7 @@ checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7201,7 +7236,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -7222,7 +7257,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7255,7 +7290,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,9 @@ axum-server = "0.8.0"
 base64 = "0.22.1"
 bytes = "1.10.0"
 candid = "0.10.10"
-candid_parser = "0.3"
-chacha20poly1305 = "0.10.1"
+candid_parser = "0.4"
+# 0.11 breaks ZeroizeOnDrop it seems
+chacha20poly1305 = "0.10"
 chrono = "0.4"
 clap = { version = "4.5.20", features = ["derive", "string", "env"] }
 criterion = { version = "0.6", features = ["html_reports"] }
@@ -72,8 +73,8 @@ instant-acme = { version = "0.8.5", default-features = false, features = [
     "aws-lc-rs",
     "hyper-rustls",
 ] }
-itertools = "0.14.0"
-mail-auth = "0.9.0"
+itertools = "0.15.0"
+mail-auth = "0.11.0"
 mail-parser = { version = "0.11.3", features = ["full_encoding"] }
 mail-send = { version = "0.6.0", default-features = false, features = [
     "builder",
@@ -81,7 +82,7 @@ mail-send = { version = "0.6.0", default-features = false, features = [
 mockall = "0.13.0"
 mock-io = { version = "0.3.2", features = ["full"] }
 moka = { version = "0.12.15", features = ["sync"] }
-nix = { version = "0.30.0", features = ["signal"] }
+nix = { version = "0.31.0", features = ["signal"] }
 ppp = "2.3.0"
 parse-size = { version = "1.1.0", features = ["std"] }
 pem = "3.0.5"
@@ -126,6 +127,7 @@ serde_cbor = "0.11.2"
 serde_json = "1.0.132"
 serde_with = "3.14.0"
 serde_yaml_ng = "0.10"
+# Sev 8.0+ requires uuid 1.18+
 sev = { version = "7.1.0", default-features = false, features = [
     "snp",
     "crypto_nossl",
@@ -154,7 +156,7 @@ tokio-util = { version = "0.7.12", features = ["full"] }
 tower = { version = "0.5.1", features = ["util"] }
 tower_governor = { version = "0.8" }
 tower-service = "0.3.3"
-tower-http = { version = "0.6.6", features = ["trace"] }
+tower-http = { version = "0.7", features = ["trace"] }
 tracing = { version = "0.1.40", features = ["attributes"] }
 url = "2.5.3"
 utoipa = { version = "5.4.0", features = ["axum_extras"] }
@@ -162,7 +164,7 @@ utoipa-swagger-ui = { version = "9.0.2", features = ["axum"] }
 # DO NOT upgrade, this breaks monorepo compatibility
 # Read https://github.com/uuid-rs/uuid/releases/tag/1.13.0
 uuid = { version = "=1.12.1", features = ["v7", "serde"] }
-vrl = { version = "0.33.0", default-features = false, features = ["value"] }
+vrl = { version = "0.34.0", default-features = false, features = ["value"] }
 webpki-root-certs = "1.0.1"
 x509-parser = "0.18.1"
 zeroize = { version = "1.8.1", features = ["derive"] }

--- a/ic-bn-lib/src/custom_domains/base/types/acme.rs
+++ b/ic-bn-lib/src/custom_domains/base/types/acme.rs
@@ -6,9 +6,10 @@ use reqwest::Url;
 
 use crate::{
     dns::{Options as DnsOptions, resolvers::Resolver},
+    http::client::ClientOptions,
     tls::acme::{
         AcmeUrl,
-        client::{Client, ClientBuilder},
+        client::{Client, ClientBuilder, HttpClient},
         dns::{
             TokenManagerDns,
             cloudflare::{Cloudflare, DEFAULT_CLOUDFLARE_URL},
@@ -122,12 +123,14 @@ impl AcmeClientConfig {
         let dns_resolver =
             Resolver::new(self.dns_options).context("unable to create DNS Resolver")?;
         let token_manager = Arc::new(TokenManagerDns::new(
-            Arc::new(dns_resolver),
+            Arc::new(dns_resolver.clone()),
             cloudflare,
             self.delegation_domain,
         ));
 
-        let builder = ClientBuilder::new(self.insecure_tls)
+        let http_client = HttpClient::new(ClientOptions::default(), dns_resolver);
+
+        let builder = ClientBuilder::new(Box::new(http_client))
             .with_acme_url(self.acme_url.clone())
             .with_token_manager(token_manager);
 
@@ -138,7 +141,7 @@ impl AcmeClientConfig {
                 .context("unable to load ACME account")?
         } else {
             let (builder, _) = builder
-                .create_account("mailto:boundary-nodes@dfinity.org")
+                .create_account("boundary-nodes@dfinity.org")
                 .await
                 .context("unable to create ACME account")?;
 

--- a/ic-bn-lib/src/custom_domains/tests/e2e_test.rs
+++ b/ic-bn-lib/src/custom_domains/tests/e2e_test.rs
@@ -15,6 +15,7 @@ use x509_parser::{parse_x509_certificate, prelude::GeneralName};
 
 use super::helpers::{TestEnv, init_logging};
 
+use crate::tls::acme::client::HttpClient;
 use crate::tls::acme::{AcmeCertificateClient, AcmeUrl, TokenManager};
 use crate::{
     custom_domains::{
@@ -107,11 +108,11 @@ async fn create_acme_client(
     addr_acme: String,
     token_manager: Arc<dyn TokenManager>,
 ) -> anyhow::Result<Arc<dyn AcmeCertificateClient>> {
-    let builder = ClientBuilder::new(true)
+    let builder = ClientBuilder::new(Box::new(HttpClient::default_insecure()))
         .with_acme_url(AcmeUrl::Custom(format!("https://{addr_acme}/dir").parse()?))
         .with_token_manager(token_manager);
 
-    let (builder, _contract) = builder.create_account("mailto:foo@bar.com").await?;
+    let (builder, _contract) = builder.create_account("foo@bar.com").await?;
 
     let acme_client = builder
         .build()

--- a/ic-bn-lib/src/http/client/clients_hyper.rs
+++ b/ic-bn-lib/src/http/client/clients_hyper.rs
@@ -48,6 +48,71 @@ where
     }
 }
 
+/// Creates a Hyper client from provided options & resolver
+pub fn new<B, R>(
+    opts: ClientOptions,
+    resolver: R,
+) -> ClientHyper<HttpsConnector<HttpConnector<R>>, B>
+where
+    B: Body + Send + 'static + Unpin,
+    B::Data: Send,
+    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    R: CloneableHyperDnsResolver,
+{
+    let mut http_conn = HttpConnector::new_with_resolver(resolver);
+    http_conn.set_connect_timeout(Some(opts.timeout_connect));
+    http_conn.set_keepalive(opts.tcp_keepalive_delay);
+    http_conn.set_keepalive_interval(opts.tcp_keepalive_interval);
+    http_conn.set_keepalive_retries(opts.tcp_keepalive_retries);
+    http_conn.enforce_http(false);
+    http_conn.set_nodelay(true);
+    http_conn.set_reuse_address(true);
+    http_conn.set_happy_eyeballs_timeout(Some(opts.happy_eyeballs_timeout));
+
+    let builder = HttpsConnector::<HttpConnector>::builder();
+    let mut builder = if let Some(mut v) = opts.tls_config {
+        // Hyper is sad when we set our ALPN
+        v.alpn_protocols = vec![];
+        builder.with_tls_config(v)
+    } else {
+        builder.with_platform_verifier()
+    }
+    .https_or_http();
+
+    if let Some(v) = opts.tls_fixed_name {
+        let name = DnsName::try_from(v).expect("able to parse as DNSName");
+        builder = builder.with_server_name_resolver(FixedServerNameResolver::new(
+            rustls::pki_types::ServerName::DnsName(name),
+        ))
+    }
+
+    let https_conn = match opts.http_version {
+        HttpVersion::Http1 => builder.enable_http1().wrap_connector(http_conn),
+        HttpVersion::Http2 => builder.enable_http2().wrap_connector(http_conn),
+        HttpVersion::All => builder.enable_all_versions().wrap_connector(http_conn),
+    };
+
+    let mut builder = ClientHyper::builder(TokioExecutor::new());
+    builder
+        .http2_adaptive_window(true)
+        .http2_keep_alive_interval(opts.http2_keepalive)
+        .http2_keep_alive_while_idle(opts.http2_keepalive_idle)
+        .pool_idle_timeout(opts.pool_idle_timeout)
+        .pool_timer(TokioTimer::new())
+        .timer(TokioTimer::new())
+        .retry_canceled_requests(true);
+
+    if let Some(v) = opts.http2_keepalive_timeout {
+        builder.http2_keep_alive_timeout(v);
+    }
+
+    if let Some(v) = opts.pool_idle_max {
+        builder.pool_max_idle_per_host(v);
+    }
+
+    builder.build(https_conn)
+}
+
 impl<B, R> HyperClient<B, R>
 where
     B: Body + Send + 'static + Unpin,
@@ -56,59 +121,9 @@ where
     R: CloneableHyperDnsResolver,
 {
     pub fn new(opts: ClientOptions, resolver: R) -> Self {
-        let mut http_conn = HttpConnector::new_with_resolver(resolver);
-        http_conn.set_connect_timeout(Some(opts.timeout_connect));
-        http_conn.set_keepalive(opts.tcp_keepalive_delay);
-        http_conn.set_keepalive_interval(opts.tcp_keepalive_interval);
-        http_conn.set_keepalive_retries(opts.tcp_keepalive_retries);
-        http_conn.enforce_http(false);
-        http_conn.set_nodelay(true);
-        http_conn.set_reuse_address(true);
-        http_conn.set_happy_eyeballs_timeout(Some(opts.happy_eyeballs_timeout));
-
-        let builder = HttpsConnector::<HttpConnector>::builder();
-        let mut builder = if let Some(mut v) = opts.tls_config {
-            // Hyper is sad when we set our ALPN
-            v.alpn_protocols = vec![];
-            builder.with_tls_config(v)
-        } else {
-            builder.with_webpki_roots()
+        Self {
+            cli: new(opts, resolver),
         }
-        .https_or_http();
-
-        if let Some(v) = opts.tls_fixed_name {
-            let name = DnsName::try_from(v).expect("able to parse as DNSName");
-            builder = builder.with_server_name_resolver(FixedServerNameResolver::new(
-                rustls::pki_types::ServerName::DnsName(name),
-            ))
-        }
-
-        let https_conn = match opts.http_version {
-            HttpVersion::Http1 => builder.enable_http1().wrap_connector(http_conn),
-            HttpVersion::Http2 => builder.enable_http2().wrap_connector(http_conn),
-            HttpVersion::All => builder.enable_all_versions().wrap_connector(http_conn),
-        };
-
-        let mut builder = ClientHyper::builder(TokioExecutor::new());
-        builder
-            .http2_adaptive_window(true)
-            .http2_keep_alive_interval(opts.http2_keepalive)
-            .http2_keep_alive_while_idle(opts.http2_keepalive_idle)
-            .pool_idle_timeout(opts.pool_idle_timeout)
-            .pool_timer(TokioTimer::new())
-            .timer(TokioTimer::new())
-            .retry_canceled_requests(true);
-
-        if let Some(v) = opts.http2_keepalive_timeout {
-            builder.http2_keep_alive_timeout(v);
-        }
-
-        if let Some(v) = opts.pool_idle_max {
-            builder.pool_max_idle_per_host(v);
-        }
-
-        let cli = builder.build(https_conn);
-        Self { cli }
     }
 }
 

--- a/ic-bn-lib/src/tests/pebble.rs
+++ b/ic-bn-lib/src/tests/pebble.rs
@@ -422,7 +422,7 @@ pub mod dns {
     use async_trait::async_trait;
 
     #[cfg(feature = "acme-dns")]
-    use crate::tls::acme::{DnsManager, Record};
+    use crate::tls::acme::{Record, dns::DnsManager};
     use serde_json::json;
     use url::Url;
 

--- a/ic-bn-lib/src/tls/acme/alpn.rs
+++ b/ic-bn-lib/src/tls/acme/alpn.rs
@@ -8,7 +8,7 @@ use rustls::{
     sign::CertifiedKey,
 };
 use rustls_acme::{
-    AcmeConfig, AcmeState, ResolvesServerCertAcme, caches::DirCache,
+    AccountCache, AcmeConfig, AcmeState, ResolvesServerCertAcme, caches::DirCache,
     futures_rustls::rustls::ClientConfig,
 };
 use tokio::sync::Mutex;
@@ -17,12 +17,39 @@ use tracing::warn;
 
 use crate::{tasks::Run, tls::acme::AcmeUrl};
 
+/// Simple AccountCache implementation that just gives out a predefined account.
+/// Store is a noop.
+struct StubAccountCache(Vec<u8>);
+
+#[async_trait]
+impl AccountCache for StubAccountCache {
+    type EA = std::io::Error;
+
+    async fn load_account(
+        &self,
+        _contact: &[String],
+        _directory_url: &str,
+    ) -> Result<Option<Vec<u8>>, Self::EA> {
+        Ok(Some(self.0.clone()))
+    }
+
+    async fn store_account(
+        &self,
+        _contact: &[String],
+        _directory_url: &str,
+        _account: &[u8],
+    ) -> Result<(), Self::EA> {
+        Ok(())
+    }
+}
+
 #[derive(derive_new::new)]
 pub struct Opts {
     pub acme_url: AcmeUrl,
     pub domains: Vec<String>,
     pub contact: String,
     pub cache_path: PathBuf,
+    pub account_credentials: Option<Vec<u8>>,
     pub tls_config: Option<ClientConfig>,
 }
 
@@ -41,13 +68,21 @@ impl AcmeAlpn {
         } else {
             AcmeConfig::new(opts.domains)
         }
-        .contact_push(opts.contact)
+        .contact_push(format!("mailto:{}", opts.contact))
         .directory(opts.acme_url.to_string());
 
-        let state = state.cache(DirCache::new(opts.cache_path)).state();
-        let resolver = state.resolver();
+        let cert_cache = DirCache::new(opts.cache_path);
 
-        Self(Mutex::new(state), resolver)
+        // If the credentials were provided - use a stub account cache
+        let state = if let Some(v) = opts.account_credentials {
+            state.cache_compose(cert_cache, StubAccountCache(v))
+        } else {
+            state.cache(cert_cache)
+        }
+        .state();
+
+        let cert_resolver = state.resolver();
+        Self(Mutex::new(state), cert_resolver)
     }
 }
 

--- a/ic-bn-lib/src/tls/acme/client.rs
+++ b/ic-bn-lib/src/tls/acme/client.rs
@@ -139,7 +139,7 @@ impl ClientBuilder {
             .unwrap()
             .create(
                 &NewAccount {
-                    contact: &[contact],
+                    contact: &[&format!("mailto:{contact}")],
                     terms_of_service_agreed: true,
                     only_return_existing: false,
                 },

--- a/ic-bn-lib/src/tls/acme/client.rs
+++ b/ic-bn-lib/src/tls/acme/client.rs
@@ -4,57 +4,62 @@ use anyhow::Context;
 use async_trait::async_trait;
 use bytes::Bytes;
 use http::Request;
-use hyper_util::{
-    client::legacy::{Client as HyperClient, connect::HttpConnector},
-    rt::TokioExecutor,
-};
+use hyper_util::client::legacy::{Client as HyperClient, connect::HttpConnector};
 use instant_acme::{
-    Account, AccountCredentials, AuthorizationHandle, AuthorizationStatus, BodyWrapper,
-    BytesResponse, ChallengeHandle, ChallengeType, Error as AcmeError,
-    HttpClient as HttpClientTrait, Identifier, NewAccount, NewOrder, Order, OrderStatus,
+    Account, AccountBuilder, AccountCredentials, AuthorizationHandle, AuthorizationStatus,
+    BodyWrapper, BytesResponse, ChallengeHandle, ChallengeType, Error as AcmeError,
+    HttpClient as AcmeHttpClientTrait, Identifier, NewAccount, NewOrder, Order, OrderStatus,
     RetryPolicy, RevocationRequest,
 };
 use rcgen::{CertificateParams, DistinguishedName, KeyPair};
+use rustls::ClientConfig;
 use tracing::{debug, instrument, warn};
 
 use crate::{
-    RetryError, retry_async,
+    RetryError,
+    dns::resolvers::{CloneableHyperDnsResolver, Resolver},
+    http::client::{ClientOptions, clients_hyper},
+    retry_async,
     tls::{
         acme::{AcmeCert, AcmeCertificateClient, AcmeUrl, Error, TokenManager},
-        prepare_client_config,
         verify::NoopServerCertVerifier,
     },
 };
 
-struct HttpClient(HyperClient<hyper_rustls::HttpsConnector<HttpConnector>, BodyWrapper<Bytes>>);
+pub struct HttpClient<R>(
+    HyperClient<hyper_rustls::HttpsConnector<HttpConnector<R>>, BodyWrapper<Bytes>>,
+);
 
-impl HttpClient {
-    /// Create a new client
-    fn new(insecure_tls: bool) -> Self {
-        let mut tls_config =
-            prepare_client_config(&[&rustls::version::TLS13, &rustls::version::TLS12]);
-
-        // Hyper doesn't like when ALPN is set
-        tls_config.alpn_protocols = vec![];
-
-        if insecure_tls {
-            tls_config
-                .dangerous()
-                .set_certificate_verifier(Arc::new(NoopServerCertVerifier::default()));
-        }
-
-        let connector = hyper_rustls::HttpsConnectorBuilder::new()
-            .with_tls_config(tls_config)
-            .https_or_http()
-            .enable_http1()
-            .enable_http2()
-            .build();
-
-        Self(HyperClient::builder(TokioExecutor::new()).build(connector))
+impl Default for HttpClient<Resolver> {
+    fn default() -> Self {
+        Self::new(ClientOptions::default(), Resolver::default())
     }
 }
 
-impl HttpClientTrait for HttpClient {
+impl HttpClient<Resolver> {
+    /// Create a client with TLS certificate verification disabled.
+    /// To be used only in tests.
+    pub fn default_insecure() -> Self {
+        let mut opts = ClientOptions::default();
+        opts.tls_config = Some(
+            ClientConfig::builder()
+                .dangerous()
+                .with_custom_certificate_verifier(Arc::new(NoopServerCertVerifier::default()))
+                .with_no_client_auth(),
+        );
+
+        Self::new(opts, Resolver::default())
+    }
+}
+
+impl<R: CloneableHyperDnsResolver> HttpClient<R> {
+    /// Create a new ACME HTTP client
+    pub fn new(opts: ClientOptions, resolver: R) -> Self {
+        Self(clients_hyper::new(opts, resolver))
+    }
+}
+
+impl<R: CloneableHyperDnsResolver> AcmeHttpClientTrait for HttpClient<R> {
     fn request(
         &self,
         req: Request<BodyWrapper<Bytes>>,
@@ -89,29 +94,38 @@ impl Default for Opts {
     }
 }
 
-/// Builder that builds a Client
+/// Builder for the ACME [`Client`]
 pub struct ClientBuilder {
     opts: Opts,
     account: Option<Account>,
-    insecure_tls: bool,
+    account_builder: Option<AccountBuilder>,
     token_manager: Option<Arc<dyn TokenManager>>,
 }
 
 impl Default for ClientBuilder {
     fn default() -> Self {
-        Self::new(false)
+        Self::new(Box::new(HttpClient::default()))
     }
 }
 
 impl ClientBuilder {
-    /// Create a new builder, optionally with an insecure TLS
-    pub fn new(insecure_tls: bool) -> Self {
+    /// Create a new builder with a provided HTTP client implementation
+    pub fn new(client: Box<dyn AcmeHttpClientTrait>) -> Self {
         Self {
             opts: Opts::default(),
             account: None,
-            insecure_tls,
+            account_builder: Some(Account::builder_with_http(client)),
             token_manager: None,
         }
+    }
+
+    /// Create a new builder that creates an HTTP client from provided options & resolver
+    pub fn new_with_http_opts<R: CloneableHyperDnsResolver>(
+        opts: ClientOptions,
+        resolver: R,
+    ) -> Self {
+        let client = HttpClient::new(opts, resolver);
+        Self::new(Box::new(client))
     }
 
     /// Create the account with the provided contact
@@ -119,18 +133,20 @@ impl ClientBuilder {
         mut self,
         contact: &str,
     ) -> Result<(Self, AccountCredentials), AcmeError> {
-        let (account, creds) =
-            Account::builder_with_http(Box::new(HttpClient::new(self.insecure_tls)))
-                .create(
-                    &NewAccount {
-                        contact: &[contact],
-                        terms_of_service_agreed: true,
-                        only_return_existing: false,
-                    },
-                    self.opts.url.to_string(),
-                    None,
-                )
-                .await?;
+        let (account, creds) = self
+            .account_builder
+            .take()
+            .unwrap()
+            .create(
+                &NewAccount {
+                    contact: &[contact],
+                    terms_of_service_agreed: true,
+                    only_return_existing: false,
+                },
+                self.opts.url.to_string(),
+                None,
+            )
+            .await?;
 
         self.account = Some(account);
         Ok((self, creds))
@@ -141,7 +157,10 @@ impl ClientBuilder {
         mut self,
         credentials: AccountCredentials,
     ) -> Result<Self, AcmeError> {
-        let account = Account::builder_with_http(Box::new(HttpClient::new(self.insecure_tls)))
+        let account = self
+            .account_builder
+            .take()
+            .unwrap()
             .from_credentials(credentials)
             .await?;
 
@@ -165,25 +184,29 @@ impl ClientBuilder {
         self
     }
 
-    /// Set the order timeout. Default is 60s.
+    /// Set the order timeout.
+    /// Default is 60s.
     pub const fn with_order_timeout(mut self, order_timeout: Duration) -> Self {
         self.opts.order_timeout = order_timeout;
         self
     }
 
-    /// Set the token timeout. Default is 60s.
+    /// Set the token timeout.
+    /// Default is 60s.
     pub const fn with_token_timeout(mut self, token_timeout: Duration) -> Self {
         self.opts.token_timeout = token_timeout;
         self
     }
 
-    /// Set the ACME URL. Default is LetsEncrypt Staging.
+    /// Set the ACME URL.
+    /// Default is LetsEncrypt Staging.
     pub fn with_acme_url(mut self, url: AcmeUrl) -> Self {
         self.opts.url = url;
         self
     }
 
-    /// Set the challenge type. Default is DNS-01.
+    /// Set the challenge type.
+    /// Default is DNS-01.
     pub fn with_challenge(mut self, challenge: ChallengeType) -> Self {
         self.opts.challenge = challenge;
         self
@@ -501,7 +524,7 @@ mod test {
                 .unwrap(),
         ));
 
-        let builder = ClientBuilder::new(true)
+        let builder = ClientBuilder::new(Box::new(HttpClient::default_insecure()))
             .with_acme_url(AcmeUrl::Custom(
                 format!("https://{}/dir", pebble_env.addr_acme())
                     .parse()
@@ -509,7 +532,7 @@ mod test {
             ))
             .with_token_manager(tm);
 
-        let (builder, _) = builder.create_account("mailto:foo@bar.com").await.unwrap();
+        let (builder, _) = builder.create_account("foo@bar.com").await.unwrap();
         let cli = builder.build().await.unwrap();
 
         let cert = cli

--- a/ic-bn-lib/src/tls/acme/client.rs
+++ b/ic-bn-lib/src/tls/acme/client.rs
@@ -136,7 +136,9 @@ impl ClientBuilder {
         let (account, creds) = self
             .account_builder
             .take()
-            .unwrap()
+            .ok_or_else(|| {
+                AcmeError::Other(Box::new(std::io::Error::other("account already loaded")))
+            })?
             .create(
                 &NewAccount {
                     contact: &[&format!("mailto:{contact}")],
@@ -160,7 +162,9 @@ impl ClientBuilder {
         let account = self
             .account_builder
             .take()
-            .unwrap()
+            .ok_or_else(|| {
+                AcmeError::Other(Box::new(std::io::Error::other("account already loaded")))
+            })?
             .from_credentials(credentials)
             .await?;
 

--- a/ic-bn-lib/src/tls/acme/dns/cloudflare.rs
+++ b/ic-bn-lib/src/tls/acme/dns/cloudflare.rs
@@ -1,9 +1,10 @@
-use super::{DnsManager, Record};
 use anyhow::{Context, Error, anyhow};
 use async_trait::async_trait;
 use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
 use tracing::debug;
+
+use super::{DnsManager, Record};
 
 pub const DEFAULT_CLOUDFLARE_URL: &str = "https://api.cloudflare.com/";
 

--- a/ic-bn-lib/src/tls/acme/dns/cloudflare.rs
+++ b/ic-bn-lib/src/tls/acme/dns/cloudflare.rs
@@ -60,16 +60,22 @@ pub struct Cloudflare {
 }
 
 impl Cloudflare {
+    /// Create a new Cloudflare client with a default HTTP client
     pub fn new(base_url: Url, token: String) -> Result<Self, Error> {
         let client = Client::builder()
             .build()
             .context("failed to initialize HTTP client")?;
 
-        Ok(Self {
+        Ok(Self::new_with_http_client(base_url, token, client))
+    }
+
+    /// Create a new Cloudflare client with a provided HTTP client
+    pub const fn new_with_http_client(base_url: Url, token: String, client: Client) -> Self {
+        Self {
             client,
             base_url,
             token,
-        })
+        }
     }
 
     /// GET /client/v4/zones?name=<zone>

--- a/ic-bn-lib/src/tls/acme/dns/mod.rs
+++ b/ic-bn-lib/src/tls/acme/dns/mod.rs
@@ -237,7 +237,7 @@ impl AcmeDns {
         } else {
             // Finally just create a new account
             let (builder2, creds) = builder
-                .create_account(&format!("mailto:{}", opts.contact))
+                .create_account(&opts.contact)
                 .await
                 .context("unable to create ACME account")?;
             builder = builder2;

--- a/ic-bn-lib/src/tls/acme/dns/mod.rs
+++ b/ic-bn-lib/src/tls/acme/dns/mod.rs
@@ -33,7 +33,7 @@ use crate::{
     tasks::Run,
     tls::{
         acme::{
-            AcmeCertificateClient as _, AcmeUrl, DnsManager, Record, TokenManager,
+            AcmeCertificateClient as _, AcmeUrl, Record, TokenManager,
             client::{Client, ClientBuilder},
         },
         extract_sans, pem_convert_to_rustls_single, sni_matches,
@@ -45,6 +45,20 @@ const FILE_CERT: &str = "cert.pem";
 
 // 60s is the lowest possible Cloudflare TTL
 const TTL: u32 = 60;
+
+/// ACME trait to manage DNS entries
+#[async_trait]
+pub trait DnsManager: Sync + Send {
+    async fn create(
+        &self,
+        zone: &str,
+        name: &str,
+        record: Record,
+        ttl: u32,
+    ) -> Result<(), anyhow::Error>;
+
+    async fn delete(&self, zone: &str, name: &str) -> Result<(), anyhow::Error>;
+}
 
 /// Manages ACME tokens using DNS.
 /// It creates `_acme-challenge` TXT records and verifies

--- a/ic-bn-lib/src/tls/acme/dns/mod.rs
+++ b/ic-bn-lib/src/tls/acme/dns/mod.rs
@@ -14,7 +14,7 @@ use core::fmt;
 use derive_new::new;
 use fqdn::FQDN;
 use hickory_proto::rr::RecordType;
-use instant_acme::AccountCredentials;
+use instant_acme::{AccountCredentials, HttpClient as AcmeHttpClientTrait};
 use rustls::{
     server::{ClientHello, ResolvesServerCert},
     sign::CertifiedKey,
@@ -27,7 +27,8 @@ use x509_parser::prelude::{FromDer, X509Certificate};
 
 use crate::{
     RetryError,
-    dns::resolvers::Resolves,
+    dns::resolvers::{CloneableHyperDnsResolver, Resolves},
+    http::client::ClientOptions,
     retry_async,
     tasks::Run,
     tls::{
@@ -148,15 +149,35 @@ pub struct Opts {
     pub path: PathBuf,
     pub domains: Vec<FQDN>,
     pub wildcard: bool,
+    pub contact: String,
     pub renew_before: Duration,
     pub account_credentials: Option<AccountCredentials>,
     pub token_manager: Arc<dyn TokenManager>,
-    pub insecure_tls: bool,
 }
 
 impl AcmeDns {
-    pub async fn new(opts: Opts) -> Result<Self, Error> {
-        let mut builder = ClientBuilder::new(opts.insecure_tls)
+    /// Create a new [`AcmeDns`] client from provided HTTP options & resolver
+    pub async fn new_with_http_opts<R: CloneableHyperDnsResolver>(
+        opts: Opts,
+        http_opts: ClientOptions,
+        resolver: R,
+    ) -> Result<Self, Error> {
+        let acme_client_builder = ClientBuilder::new_with_http_opts(http_opts, resolver);
+        Self::new(opts, acme_client_builder).await
+    }
+
+    /// Create a new [`AcmeDns`] client from a provided HTTP client
+    pub async fn new_with_http_client(
+        opts: Opts,
+        http_client: Box<dyn AcmeHttpClientTrait>,
+    ) -> Result<Self, Error> {
+        let acme_client_builder = ClientBuilder::new(http_client);
+        Self::new(opts, acme_client_builder).await
+    }
+
+    /// Create a new [`AcmeDns`] client from a provided Acme client builder
+    pub async fn new(opts: Opts, mut builder: ClientBuilder) -> Result<Self, Error> {
+        builder = builder
             .with_acme_url(opts.acme_url)
             .with_token_manager(opts.token_manager);
         let account_path = opts.path.join("account.json");
@@ -183,10 +204,17 @@ impl AcmeDns {
                 .load_account(v)
                 .await
                 .context("unable to load ACME account")?;
-        } else if let Ok(v) = fs::read(&account_path).await {
+        } else if fs::try_exists(&account_path)
+            .await
+            .context("unable to check account.json existence")?
+        {
+            let js = fs::read(&account_path)
+                .await
+                .context("unable to read account.json")?;
+
             // Otherwise first try to load them from file
-            let creds: AccountCredentials =
-                serde_json::from_slice(&v).context("unable to parse ACME account credentials")?;
+            let creds: AccountCredentials = serde_json::from_slice(&js)
+                .context("unable to parse ACME account credentials from JSON")?;
 
             builder = builder
                 .load_account(creds)
@@ -195,7 +223,7 @@ impl AcmeDns {
         } else {
             // Finally just create a new account
             let (builder2, creds) = builder
-                .create_account("mailto:boundary-nodes@dfinity.org")
+                .create_account(&format!("mailto:{}", opts.contact))
                 .await
                 .context("unable to create ACME account")?;
             builder = builder2;
@@ -337,7 +365,7 @@ mod test {
     use super::*;
     use crate::{
         tests::pebble::{Env, dns::TokenManagerPebble},
-        tls::extract_sans_der,
+        tls::{acme::client::HttpClient, extract_sans_der},
     };
 
     #[ignore]
@@ -365,14 +393,17 @@ mod test {
             ),
             path: dir.path().to_path_buf(),
             domains: vec![fqdn!("foo")],
+            contact: "foo@bar.com".into(),
             wildcard: true,
             renew_before: Duration::from_secs(30),
             account_credentials: None,
             token_manager: token_manager_dns,
-            insecure_tls: true,
         };
 
-        let acme_dns = AcmeDns::new(opts).await.unwrap();
+        let acme_dns =
+            AcmeDns::new_with_http_client(opts, Box::new(HttpClient::default_insecure()))
+                .await
+                .unwrap();
         assert_eq!(acme_dns.refresh().await.unwrap(), RefreshResult::Refreshed);
         let cert = acme_dns.cert.load_full().unwrap();
         let mut sans = extract_sans_der(cert.end_entity_cert().unwrap()).unwrap();

--- a/ic-bn-lib/src/tls/acme/mod.rs
+++ b/ic-bn-lib/src/tls/acme/mod.rs
@@ -26,17 +26,23 @@ pub trait TokenManager: Sync + Send {
     async fn verify(&self, id: &str, token: &str) -> Result<(), anyhow::Error>;
 }
 
-/// ACME trait to manage DNS entries
+/// Token manager that does nothing.
+/// Usable when you don't need to set tokens like in DNS-PERSIST-01 challenge
+pub struct TokenManagerNoop;
+
 #[async_trait]
-pub trait DnsManager: Sync + Send {
-    async fn create(
-        &self,
-        zone: &str,
-        name: &str,
-        record: Record,
-        ttl: u32,
-    ) -> Result<(), anyhow::Error>;
-    async fn delete(&self, zone: &str, name: &str) -> Result<(), anyhow::Error>;
+impl TokenManager for TokenManagerNoop {
+    async fn verify(&self, _zone: &str, _token: &str) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
+
+    async fn set(&self, _zone: &str, _token: &str) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
+
+    async fn unset(&self, _zone: &str) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
 }
 
 /// ACME client trait to issue and revoke certificates
@@ -59,6 +65,7 @@ pub trait AcmeCertificateClient: Sync + Send {
 pub enum Challenge {
     Alpn,
     Dns,
+    DnsPersist,
 }
 
 /// Type of ACME server.

--- a/ic-bn-lib/tools/cloudflare-test.rs
+++ b/ic-bn-lib/tools/cloudflare-test.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use ic_bn_lib::tls::acme::{DnsManager, Record, dns::cloudflare::Cloudflare};
+use ic_bn_lib::tls::acme::{Record, dns::DnsManager, dns::cloudflare::Cloudflare};
 
 #[derive(Parser)]
 pub struct Cli {


### PR DESCRIPTION
* Add preliminary support for the upcoming DNS-PERSIST-01 challenge with a help of `TokenManagerNoop`. `instant_acme` crate does not support it yet.
* Factor out creation of Hyper client to be able to reuse it in ACME
* Allow to specify HTTP/DNS options for ACME HTTP client to align with other parts of the crate
* Allow to provide a custom reqwest Client for Cloudflare
* Add ability to use an existing ACME account in ALPN mode
* Crate updates